### PR TITLE
Add login page

### DIFF
--- a/src/components/shared/Copyright.tsx
+++ b/src/components/shared/Copyright.tsx
@@ -1,0 +1,25 @@
+import {Divider} from '@mui/material'
+import Typography from '@mui/material/Typography'
+import Box from '@mui/material/Box'
+
+function Copyright() {
+    return (
+        <Box sx={{p: 6}} component="footer">
+            <Divider sx={{mb: 2}}/>
+            <Typography variant="subtitle1" align="center" gutterBottom>
+                {'Powered by gipfeli.io '}
+                {new Date().getFullYear()}
+            </Typography>
+            <Typography
+                variant="subtitle1"
+                align="center"
+                color="text.secondary"
+                component="p"
+            >
+                Made with ☕ and ❤ in Switzerland.
+            </Typography>
+        </Box>
+    )
+}
+
+export default Copyright

--- a/src/components/shared/Copyright.tsx
+++ b/src/components/shared/Copyright.tsx
@@ -4,17 +4,17 @@ import Box from '@mui/material/Box'
 
 function Copyright() {
     return (
-        <Box sx={{p: 6}} component="footer">
+        <Box sx={{p: 6}} component='footer'>
             <Divider sx={{mb: 2}}/>
-            <Typography variant="subtitle1" align="center" gutterBottom>
+            <Typography variant='subtitle1' align='center' gutterBottom>
                 {'Powered by gipfeli.io '}
                 {new Date().getFullYear()}
             </Typography>
             <Typography
-                variant="subtitle1"
-                align="center"
-                color="text.secondary"
-                component="p"
+                variant='subtitle1'
+                align='center'
+                color='text.secondary'
+                component='p'
             >
                 Made with ☕ and ❤ in Switzerland.
             </Typography>

--- a/src/layouts/auth-page.tsx
+++ b/src/layouts/auth-page.tsx
@@ -11,23 +11,23 @@ import Link from 'next/link'
 function authPage(page: ReactElement) {
     return (
         <>
-            <AppBar position="fixed" color="transparent" elevation={0}>
+            <AppBar position='fixed' color='transparent' elevation={0}>
                 <Toolbar>
                     <Link href={'/'} passHref>
                         <IconButton
-                            size="large"
-                            edge="start"
+                            size='large'
+                            edge='start'
                             sx={{mr: 2}}
                         >
                             <LandscapeIcon/>
                         </IconButton>
                     </Link>
-                    <Typography variant="h6" component="div" sx={{flexGrow: 1}}>
+                    <Typography variant='h6' component='div' sx={{flexGrow: 1}}>
                         gipfeli.io
                     </Typography>
                 </Toolbar>
             </AppBar>
-            <Grid container component="main" sx={{height: '100vh'}}>
+            <Grid container component='main' sx={{height: '100vh'}}>
                 <Grid
                     item
                     xs={false}

--- a/src/layouts/auth-page.tsx
+++ b/src/layouts/auth-page.tsx
@@ -1,0 +1,64 @@
+import Paper from '@mui/material/Paper'
+import Box from '@mui/material/Box'
+import Grid from '@mui/material/Grid'
+import {FormEvent, ReactElement} from 'react'
+import Copyright from '../components/shared/Copyright'
+import {AppBar, IconButton, Toolbar} from '@mui/material'
+import LandscapeIcon from '@mui/icons-material/Landscape'
+import Typography from '@mui/material/Typography'
+import Link from 'next/link'
+
+function authPage(page: ReactElement) {
+    return (
+        <>
+            <AppBar position="fixed" color="transparent" elevation={0}>
+                <Toolbar>
+                    <Link href={'/'} passHref>
+                        <IconButton
+                            size="large"
+                            edge="start"
+                            sx={{mr: 2}}
+                        >
+                            <LandscapeIcon/>
+                        </IconButton>
+                    </Link>
+                    <Typography variant="h6" component="div" sx={{flexGrow: 1}}>
+                        gipfeli.io
+                    </Typography>
+                </Toolbar>
+            </AppBar>
+            <Grid container component="main" sx={{height: '100vh'}}>
+                <Grid
+                    item
+                    xs={false}
+                    sm={4}
+                    md={7}
+                    sx={{
+                        backgroundImage: 'url(https://source.unsplash.com/random/?mountains)',
+                        backgroundRepeat: 'no-repeat',
+                        backgroundSize: 'cover',
+                        backgroundPosition: 'center',
+                    }}
+                />
+                <Grid item xs={12} sm={8} md={5} component={Paper} elevation={6} square>
+                    <Box
+                        sx={{
+                            my: 8,
+                            mx: 4,
+                            display: 'flex',
+                            flexDirection: 'column',
+                            alignItems: 'center',
+                        }}
+                    >
+
+                        {page}
+
+                    </Box>
+                    <Copyright/>
+                </Grid>
+            </Grid>
+        </>
+    )
+}
+
+export default authPage

--- a/src/layouts/landing-page.tsx
+++ b/src/layouts/landing-page.tsx
@@ -2,6 +2,8 @@ import {ReactElement} from 'react'
 import {AppBar, Box, Button, Divider, IconButton, Stack, Toolbar} from '@mui/material'
 import Typography from '@mui/material/Typography'
 import LandscapeIcon from '@mui/icons-material/Landscape'
+import Copyright from '../components/shared/Copyright'
+import Link from 'next/link'
 
 function landingPage(page: ReactElement) {
     return (
@@ -20,28 +22,16 @@ function landingPage(page: ReactElement) {
                     </Typography>
                     <Stack spacing={2} direction={'row'}>
                         <Button variant={'contained'}>Join</Button>
-                        <Button variant={'outlined'}>Login</Button>
+                        <Link href={'/app/login'} passHref>
+                            <Button variant={'outlined'}>Login</Button>
+                        </Link>
                     </Stack>
                 </Toolbar>
             </AppBar>
 
             {page}
 
-            <Box sx={{p: 6}} component='footer'>
-                <Divider sx={{mb: 2}}/>
-                <Typography variant='h6' align='center' gutterBottom>
-                    {'Powered by gipfeli.io '}
-                    {new Date().getFullYear()}
-                </Typography>
-                <Typography
-                    variant='subtitle1'
-                    align='center'
-                    color='text.secondary'
-                    component='p'
-                >
-                    Made with ☕ and ❤ in Switzerland.
-                </Typography>
-            </Box>
+            <Copyright />
         </>
     )
 }

--- a/src/pages/app/login.tsx
+++ b/src/pages/app/login.tsx
@@ -23,46 +23,46 @@ const Login: NextPageWithLayout = () => {
             <Avatar sx={{m: 1, width: 80, height: 80}}>
                 <LockOutlinedIcon/>
             </Avatar>
-            <Typography component="h1" variant="h2">
+            <Typography component='h1' variant='h2'>
                 Sign in
             </Typography>
-            <Box component="form" sx={{mt: 1}} onSubmit={login}>
+            <Box component='form' sx={{mt: 1}} onSubmit={login}>
                 <TextField
-                    margin="normal"
+                    margin='normal'
                     required
                     fullWidth
-                    id="email"
-                    label="Email Address"
-                    name="email"
-                    autoComplete="email"
+                    id='email'
+                    label='Email Address'
+                    name='email'
+                    autoComplete='email'
                     autoFocus
                 />
                 <TextField
-                    margin="normal"
+                    margin='normal'
                     required
                     fullWidth
-                    name="password"
-                    label="Password"
-                    type="password"
-                    id="password"
-                    autoComplete="current-password"
+                    name='password'
+                    label='Password'
+                    type='password'
+                    id='password'
+                    autoComplete='current-password'
                 />
                 <Button
-                    type="submit"
+                    type='submit'
                     fullWidth
-                    variant="contained"
+                    variant='contained'
                     sx={{mt: 3, mb: 2}}
                 >
                     Sign In
                 </Button>
                 <Grid container>
                     <Grid item xs>
-                        <Link href="#">
+                        <Link href='#'>
                             Forgot password?
                         </Link>
                     </Grid>
                     <Grid item>
-                        <Link href="#">
+                        <Link href='#'>
                             {'Create a free account'}
                         </Link>
                     </Grid>

--- a/src/pages/app/login.tsx
+++ b/src/pages/app/login.tsx
@@ -1,0 +1,77 @@
+import {NextPageWithLayout} from '../../types/layout'
+import authPage from '../../layouts/auth-page'
+import Avatar from '@mui/material/Avatar'
+import LockOutlinedIcon from '@mui/icons-material/LockOutlined'
+import Typography from '@mui/material/Typography'
+import Box from '@mui/material/Box'
+import TextField from '@mui/material/TextField'
+import Button from '@mui/material/Button'
+import Grid from '@mui/material/Grid'
+import Link from '@mui/material/Link'
+import {FormEvent} from 'react'
+
+const Login: NextPageWithLayout = () => {
+    const login = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault()
+        const data = new FormData(event.currentTarget)
+
+        alert(`Logging in ${data.get('email')}`)
+    }
+
+    return (
+        <>
+            <Avatar sx={{m: 1, width: 80, height: 80}}>
+                <LockOutlinedIcon/>
+            </Avatar>
+            <Typography component="h1" variant="h2">
+                Sign in
+            </Typography>
+            <Box component="form" sx={{mt: 1}} onSubmit={login}>
+                <TextField
+                    margin="normal"
+                    required
+                    fullWidth
+                    id="email"
+                    label="Email Address"
+                    name="email"
+                    autoComplete="email"
+                    autoFocus
+                />
+                <TextField
+                    margin="normal"
+                    required
+                    fullWidth
+                    name="password"
+                    label="Password"
+                    type="password"
+                    id="password"
+                    autoComplete="current-password"
+                />
+                <Button
+                    type="submit"
+                    fullWidth
+                    variant="contained"
+                    sx={{mt: 3, mb: 2}}
+                >
+                    Sign In
+                </Button>
+                <Grid container>
+                    <Grid item xs>
+                        <Link href="#">
+                            Forgot password?
+                        </Link>
+                    </Grid>
+                    <Grid item>
+                        <Link href="#">
+                            {'Create a free account'}
+                        </Link>
+                    </Grid>
+                </Grid>
+            </Box>
+        </>
+    )
+}
+
+Login.getLayout = authPage
+
+export default Login


### PR DESCRIPTION
See #3 

Adds a basic login mask without functionality:
* Add layout which differs a bit from the landing page
* Is based on the official MUI login page tutorial, could be tweaked
* The layout can also be used for all other auth-related pages such as password reset and registration