### PR TITLE
Add basic app page layout

### DIFF
--- a/src/layouts/app-page-layout.tsx
+++ b/src/layouts/app-page-layout.tsx
@@ -1,0 +1,36 @@
+import React, {PropsWithChildren} from 'react'
+import {AppBar, Container, IconButton, Toolbar} from '@mui/material'
+import Typography from '@mui/material/Typography'
+import LandscapeIcon from '@mui/icons-material/Landscape'
+import Copyright from '../components/shared/Copyright'
+import NavBarUserSection from '../components/shared/NavBarUserSection'
+
+
+function LandingPageLayout({children}: PropsWithChildren<any>) {
+    return (
+        <>
+            <AppBar position="static">
+                <Toolbar>
+                    <IconButton
+                        size="large"
+                        edge="start"
+                        sx={{mr: 2}}
+                    >
+                        <LandscapeIcon/>
+                    </IconButton>
+                    <Typography variant="h6" component="div" sx={{flexGrow: 1}}>
+                        gipfeli.io
+                    </Typography>
+                    <NavBarUserSection></NavBarUserSection>
+                </Toolbar>
+            </AppBar>
+            <Container maxWidth={'lg'}>
+                {children}
+            </Container>
+
+            <Copyright/>
+        </>
+    )
+}
+
+export default LandingPageLayout

--- a/src/pages/app/index.tsx
+++ b/src/pages/app/index.tsx
@@ -1,8 +1,8 @@
 import {NextPageContext} from 'next'
-import LandingPageLayout from '../../layouts/landing-page-layout'
 import UsersService from '../../services/users/users-service'
 import {withAuthenticatedOrRedirect} from '../../utils/with-authenticated-or-redirect'
 import {Session} from 'next-auth'
+import AppPageLayout from '../../layouts/app-page-layout'
 
 type AppHomeProps = {
     username: string
@@ -24,10 +24,10 @@ export const getServerSideProps = (context: NextPageContext) => withAuthenticate
 
 const AppHome = ({username, id}: AppHomeProps) => {
     return (
-        <LandingPageLayout>
+        <AppPageLayout>
             <h1>Username in API: {username}</h1>
             <h2>User ID: {id}</h2>
-        </LandingPageLayout>
+        </AppPageLayout>
 
     )
 }


### PR DESCRIPTION
Adds a basic layout wrapper which was missing before. We'll use this for our detail components and flesh it out later on. As an example, it could extend from landing-page-layout, or we could abstract the navbar.

The main reason for this is that we can use the same `<Container>` on all subpages.