### PR TITLE
Feature/client side fetching

### DIFF
--- a/__tests__/unit/components/__snapshots__/NavBarUserSection.test.tsx.snap
+++ b/__tests__/unit/components/__snapshots__/NavBarUserSection.test.tsx.snap
@@ -6,6 +6,20 @@ exports[`NavBarUserSection behaves consistently when logged in 1`] = `
 >
   <div
     className="MuiTypography-root MuiTypography-h6 css-1juivf6-MuiTypography-root"
+    href="/tours"
+    onClick={[Function]}
+    onMouseEnter={[Function]}
+  >
+    <a
+      className="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1ps4owl-MuiTypography-root-MuiLink-root"
+      onBlur={[Function]}
+      onFocus={[Function]}
+    >
+      MyTours
+    </a>
+  </div>
+  <div
+    className="MuiTypography-root MuiTypography-h6 css-1juivf6-MuiTypography-root"
   >
     Hello, 
     test@gipfeli.io

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "next-auth": "^4.3.4",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
-        "reflect-metadata": "^0.1.13"
+        "reflect-metadata": "^0.1.13",
+        "swr": "^1.3.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^5.16.4",
@@ -7512,6 +7513,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-1.3.0.tgz",
+      "integrity": "sha512-dkghQrOl2ORX9HYrMDtPa7LTVHJjCTeZoB1dqTbnnEDlSvN8JEKpYIYurDfvbQFUUS8Cg8PceFVZNkW0KNNYPw==",
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -13514,6 +13523,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
+    },
+    "swr": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-1.3.0.tgz",
+      "integrity": "sha512-dkghQrOl2ORX9HYrMDtPa7LTVHJjCTeZoB1dqTbnnEDlSvN8JEKpYIYurDfvbQFUUS8Cg8PceFVZNkW0KNNYPw==",
+      "requires": {}
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "next-auth": "^4.3.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "reflect-metadata": "^0.1.13"
+    "reflect-metadata": "^0.1.13",
+    "swr": "^1.3.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.4",

--- a/src/components/app/TourList.tsx
+++ b/src/components/app/TourList.tsx
@@ -1,6 +1,9 @@
 import {Tour} from '../../types/tour'
 import {DataGrid, GridColDef, GridValueGetterParams} from '@mui/x-data-grid'
 import TourListActions from './TourListActions'
+import ToursService from '../../services/tours/tours-service'
+import useSWR from 'swr'
+import {plainToInstance} from 'class-transformer'
 
 function getActions(params: GridValueGetterParams<Tour, Tour>): JSX.Element {
     return <TourListActions id={params.row.id} />
@@ -13,13 +16,17 @@ const columns: GridColDef[] = [
     {field: 'actions', headerName: 'Actions', flex: 0.5, renderCell: getActions}
 ]
 
-export default function TourList(props: { rows: Tour[] }): JSX.Element {
+export default function TourList(): JSX.Element {
+    const service = new ToursService({})
+    const { data, error } = useSWR('/api/user/123', service.mockAll)
+    //tours = plainToInstance(Tour, tours) // todo: maybe have this in a generic fashion?
+
     return <div style={{width: '100%'}}>
         <DataGrid
             autoHeight
             disableColumnSelector
             disableSelectionOnClick
-            rows={props.rows}
+            rows={data ?? []}
             columns={columns}/>
     </div>
 }

--- a/src/components/shared/AuthWrapper.tsx
+++ b/src/components/shared/AuthWrapper.tsx
@@ -1,8 +1,9 @@
 import {useSession} from 'next-auth/react'
 import {CircularProgress} from '@mui/material'
 import {useRouter} from 'next/router'
+import {PropsWithChildren} from 'react'
 
-export const AuthWrapper = (children: JSX.Element) => {
+export const AuthWrapper = ({children}: PropsWithChildren<any>) => {
     const router = useRouter()
     const {status} = useSession({
         required: true, onUnauthenticated: () => {

--- a/src/components/shared/AuthWrapper.tsx
+++ b/src/components/shared/AuthWrapper.tsx
@@ -1,0 +1,19 @@
+import {useSession} from 'next-auth/react'
+import {CircularProgress} from '@mui/material'
+import {useRouter} from 'next/router'
+
+export const AuthWrapper = (children: JSX.Element) => {
+    const router = useRouter()
+    const {status} = useSession({
+        required: true, onUnauthenticated: () => {
+            router.push('/login')
+            return null
+        }
+    })
+
+    if (status === 'loading') {
+        return <CircularProgress/>
+    }
+
+    return <>{children}</>
+}

--- a/src/components/shared/AuthWrapper.tsx
+++ b/src/components/shared/AuthWrapper.tsx
@@ -15,7 +15,5 @@ export const AuthWrapper = ({children}: PropsWithChildren<any>) => {
         return <CircularProgress/>
     }
 
-    if (status === 'authenticated') {
-        return <>{children}</>
-    }
+    return <>{children}</>
 }

--- a/src/components/shared/AuthWrapper.tsx
+++ b/src/components/shared/AuthWrapper.tsx
@@ -7,8 +7,7 @@ export const AuthWrapper = ({children}: PropsWithChildren<any>) => {
     const router = useRouter()
     const {status} = useSession({
         required: true, onUnauthenticated: () => {
-            router.push('/login')
-            return null
+            router.push('/login').then(r => null)
         }
     })
 
@@ -16,5 +15,7 @@ export const AuthWrapper = ({children}: PropsWithChildren<any>) => {
         return <CircularProgress/>
     }
 
-    return <>{children}</>
+    if (status === 'authenticated') {
+        return <>{children}</>
+    }
 }

--- a/src/components/shared/NavBarUserSection.tsx
+++ b/src/components/shared/NavBarUserSection.tsx
@@ -1,11 +1,12 @@
-import {Button, Stack} from '@mui/material'
+import {Button, Link as MuiLink, Stack} from '@mui/material'
 import React from 'react'
 import {signIn, signOut} from 'next-auth/react'
 import {useAuth} from '../../hooks/use-auth'
 import Typography from '@mui/material/Typography'
+import Link from 'next/link'
 
 function NavBarUserSection() {
-    const { user, isAuthenticated } = useAuth();
+    const {user, isAuthenticated} = useAuth()
 
     if (!isAuthenticated) {
         return (
@@ -18,6 +19,11 @@ function NavBarUserSection() {
 
     return (
         <Stack spacing={2} direction={'row'}>
+            <Link href={'/tours'} passHref>
+                <Typography variant="h6" component="div" sx={{flexGrow: 1}}>
+                    <MuiLink>MyTours</MuiLink>
+                </Typography>
+            </Link>
             <Typography variant="h6" component="div" sx={{flexGrow: 1}}>
                 Hello, {user}!
             </Typography>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,21 +6,29 @@ import {CssBaseline} from '@mui/material'
 import {ThemeProvider} from '@mui/material/styles'
 import theme from '../themes/dark'
 import {SessionProvider} from 'next-auth/react'
-import {AppProps} from 'next/app'
 import Head from 'next/head'
-import 'reflect-metadata' // todo: use webpack injector for global scoping
+import 'reflect-metadata'
+import {AuthWrapper} from '../components/shared/AuthWrapper'
+import {ExtendedAppProps} from '../types/auth-extended-page' // todo: use webpack injector for global scoping
 
-function App({Component, pageProps: {session, ...pageProps}}: AppProps) {
+function App({Component, pageProps: {session, ...pageProps}}: ExtendedAppProps) {
 
     // Todo: add a generic means to check if a user may access the page - but we need it in severside props, so...
     return (
         <ThemeProvider theme={theme}>
             <Head>
-                <meta name='viewport' content='initial-scale=1, width=device-width'/>
+                <meta name="viewport" content="initial-scale=1, width=device-width"/>
             </Head>
             <CssBaseline/>
             <SessionProvider session={session}>
-                <Component {...pageProps} />
+                {Component.isPublic ? (
+                    <Component {...pageProps} />
+                ) : (
+                    <AuthWrapper>
+                        <Component {...pageProps} />
+                    </AuthWrapper>
+
+                )}
             </SessionProvider>
         </ThemeProvider>
     )

--- a/src/pages/api/auth/[...nextauth].tsx
+++ b/src/pages/api/auth/[...nextauth].tsx
@@ -8,7 +8,7 @@ export default NextAuth({
     },
     secret: process.env.JWT_SECRET,
     session: {
-        maxAge: 60 * 60 // defaults to 1 hour of idle
+        maxAge: 10 // defaults to 1 hour of idle
     },
     providers: [
         CredentialsProvider({

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,10 +1,10 @@
 import Hero from '../components/landing-page/Hero'
 import Features from '../components/landing-page/Features'
 import {Container} from '@mui/material'
-import {NextPage} from 'next'
 import LandingPageLayout from '../layouts/landing-page-layout'
+import {NextPageWithAuth} from '../types/auth-extended-page'
 
-const Home: NextPage = () => {
+const Home: NextPageWithAuth = () => {
     return (
         <LandingPageLayout>
             <Hero/>
@@ -15,5 +15,7 @@ const Home: NextPage = () => {
 
     )
 }
+
+Home.isPublic = true
 
 export default Home

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -13,9 +13,10 @@ import AuthPageLayout from '../layouts/auth-page-layout'
 import {useRouter} from 'next/router'
 import {useAuth} from '../hooks/use-auth'
 import {Alert} from '@mui/material'
+import {NextPageWithAuth} from '../types/auth-extended-page'
 
 
-const Login: NextPage = () => {
+const Login: NextPageWithAuth = () => {
     const router = useRouter()
     const {isAuthenticated} = useAuth()
     const {error} = useRouter().query
@@ -93,5 +94,7 @@ const Login: NextPage = () => {
         </AuthPageLayout>
     )
 }
+
+Login.isPublic = true
 
 export default Login

--- a/src/pages/tours/[id]/edit.tsx
+++ b/src/pages/tours/[id]/edit.tsx
@@ -26,7 +26,7 @@ export const getServerSideProps = (context: NextPageContext) => withAuthenticate
     }
 })
 
-const EditTour: NextPageWithAuth = ({tour}: EditTourProps) => {
+const EditTour: NextPageWithAuth<EditTourProps> = ({tour}) => {
     tour = plainToInstance(Tour, tour) // todo: maybe have this in a generic fashion?
 
     return (

--- a/src/pages/tours/[id]/edit.tsx
+++ b/src/pages/tours/[id]/edit.tsx
@@ -7,6 +7,7 @@ import AppPageLayout from "../../../layouts/app-page-layout";
 import TourForm from "../../../components/app/TourForm";
 import ToursService from "../../../services/tours/tours-service";
 import {plainToInstance} from "class-transformer";
+import {NextPageWithAuth} from '../../../types/auth-extended-page'
 
 type EditTourProps = {
     tour: Tour
@@ -25,7 +26,7 @@ export const getServerSideProps = (context: NextPageContext) => withAuthenticate
     }
 })
 
-const EditTour = ({tour}: EditTourProps) => {
+const EditTour: NextPageWithAuth = ({tour}: EditTourProps) => {
     tour = plainToInstance(Tour, tour) // todo: maybe have this in a generic fashion?
 
     return (

--- a/src/pages/tours/create.tsx
+++ b/src/pages/tours/create.tsx
@@ -3,8 +3,9 @@ import Typography from "@mui/material/Typography";
 import TourForm from "../../components/app/TourForm";
 import {Tour} from "../../types/tour";
 import {Point} from 'geojson'
+import {NextPageWithAuth} from '../../types/auth-extended-page'
 
-const NewTour = () => {
+const NewTour: NextPageWithAuth = () => {
     const tour: Tour = new Tour("", "", {} as Point, {} as Point, "", new Date(), new Date())
 
     return (

--- a/src/pages/tours/index.tsx
+++ b/src/pages/tours/index.tsx
@@ -27,7 +27,7 @@ export const getServerSideProps = (context: NextPageContext) => withAuthenticate
     }
 })
 
-const AppHome: NextPageWithAuth = ({tours}: AppHomeProps): JSX.Element => {
+const AppHome: NextPageWithAuth<AppHomeProps> = ({tours}): JSX.Element => {
     tours = plainToInstance(Tour, tours) // todo: maybe have this in a generic fashion?
 
     return (

--- a/src/pages/tours/index.tsx
+++ b/src/pages/tours/index.tsx
@@ -8,6 +8,7 @@ import Typography from '@mui/material/Typography'
 import {plainToInstance} from 'class-transformer'
 import ToursService from '../../services/tours/tours-service'
 import {Button, Grid} from "@mui/material";
+import {NextPageWithAuth} from '../../types/auth-extended-page'
 
 type AppHomeProps = {
     tours: Tour[]
@@ -26,7 +27,7 @@ export const getServerSideProps = (context: NextPageContext) => withAuthenticate
     }
 })
 
-const AppHome = ({tours}: AppHomeProps): JSX.Element => {
+const AppHome: NextPageWithAuth = ({tours}: AppHomeProps): JSX.Element => {
     tours = plainToInstance(Tour, tours) // todo: maybe have this in a generic fashion?
 
     return (

--- a/src/pages/tours/index.tsx
+++ b/src/pages/tours/index.tsx
@@ -9,6 +9,7 @@ import {plainToInstance} from 'class-transformer'
 import ToursService from '../../services/tours/tours-service'
 import {Button, Grid} from "@mui/material";
 import {NextPageWithAuth} from '../../types/auth-extended-page'
+import useSWR from 'swr'
 
 type AppHomeProps = {
     tours: Tour[]
@@ -28,8 +29,6 @@ export const getServerSideProps = (context: NextPageContext) => withAuthenticate
 })
 
 const AppHome: NextPageWithAuth<AppHomeProps> = ({tours}): JSX.Element => {
-    tours = plainToInstance(Tour, tours) // todo: maybe have this in a generic fashion?
-
     return (
         <AppPageLayout>
             <Typography variant="h2" gutterBottom component="div">
@@ -42,7 +41,7 @@ const AppHome: NextPageWithAuth<AppHomeProps> = ({tours}): JSX.Element => {
                     </Button>
                 </Grid>
             </Grid>
-            <TourList rows={tours}/>
+            <TourList/>
         </AppPageLayout>
     )
 }

--- a/src/services/tours/tours-service.ts
+++ b/src/services/tours/tours-service.ts
@@ -81,7 +81,7 @@ export default class ToursService extends APIService {
     }
 
     public async mockAll(): Promise<Tour[]> {
-        await sleep(150)
+        await sleep(1500)
         return serviceResponse
     }
 

--- a/src/types/auth-extended-page.ts
+++ b/src/types/auth-extended-page.ts
@@ -1,0 +1,12 @@
+import {NextComponentType, NextPage, NextPageContext} from 'next'
+import {AppProps} from 'next/app'
+
+export type NextPageWithAuth<P = {}, IP = P> = NextPage<P, IP> & {
+    isPublic?: boolean
+};
+
+export type NextComponentWithAuth = NextComponentType<NextPageContext, any, {}> & Partial<NextPageWithAuth>
+
+export type ExtendedAppProps<P = {}> = AppProps<P> & {
+    Component: NextComponentWithAuth
+};


### PR DESCRIPTION
* Adds client-side-wrapped checking for logged in users; which is a prerequisite for having client-side fetching
* Note that the `useSwr` part is not finalized - this will become a hook that handles it more generically.
* ALso: Currently, we're exposing the whole session object in the JSON rendered by next - is that an issue?

Issue:
* For testing purposes, session is set to 10 seconds
* Reproduce by:
* 1) Log in
* 2) go to /tours
* 3) wait for 10 seconds
* 4) click the link to tours in the header

It redirects  you to the login page - but if you open the requests tab, you see an infinite fetch for tours.json, which should not happen. It only happens for the /tours endpoint and leads to infinite requests.