### PR TITLE
Feature/add tour detail view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@mui/material": "^5.6.3",
         "@mui/x-data-grid": "^5.11.0",
         "class-transformer": "^0.5.1",
+        "dayjs": "^1.11.2",
         "geojson": "^0.5.0",
         "next": "^12.1.5",
         "next-auth": "^4.3.4",
@@ -3079,6 +3080,11 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.2.tgz",
+      "integrity": "sha512-F4LXf1OeU9hrSYRPTTj/6FbO4HTjPKXvEIC1P2kcnFurViINCVk3ZV0xAS3XVx9MkMsXbbqlK6hjseaYbgKEHw=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -10203,6 +10209,11 @@
           }
         }
       }
+    },
+    "dayjs": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.2.tgz",
+      "integrity": "sha512-F4LXf1OeU9hrSYRPTTj/6FbO4HTjPKXvEIC1P2kcnFurViINCVk3ZV0xAS3XVx9MkMsXbbqlK6hjseaYbgKEHw=="
     },
     "debug": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@mui/material": "^5.6.3",
     "@mui/x-data-grid": "^5.11.0",
     "class-transformer": "^0.5.1",
+    "dayjs": "^1.11.2",
     "geojson": "^0.5.0",
     "next": "^12.1.5",
     "next-auth": "^4.3.4",

--- a/src/components/app/TourForm.tsx
+++ b/src/components/app/TourForm.tsx
@@ -16,7 +16,7 @@ export default function TourForm({tour}: formProps) {
         //todo: call service to save tour
     }
 
-    const cancel = () => router.push('/tours')
+    const cancel = () => router.back()
 
     const [currentTour, updateValue] = useState(tour)
 

--- a/src/pages/tours/[id].tsx
+++ b/src/pages/tours/[id].tsx
@@ -37,17 +37,12 @@ const TourDetail = ({tour}: TourDetailProps): JSX.Element => {
             <Grid container mb={2} direction={'row'} spacing={10}>
                 <Grid item>
                     <Typography variant="subtitle1" gutterBottom component="div">
-                        Created at: {tour.getFormattedDate()}
+                        Created at: {tour.createdAt.format('DD.MM.YYYY hh:mm')}
                     </Typography>
                 </Grid>
                 <Grid item>
                     <Typography variant="subtitle1" gutterBottom component="div">
-                        Created at: {tour.getFormattedDate()}
-                    </Typography>
-                </Grid>
-                <Grid item>
-                    <Typography variant="subtitle1" gutterBottom component="div">
-                        Updated at: {tour.getFormattedDate()}
+                        Last updated at: {tour.updatedAt.format('DD.MM.YYYY hh:mm')}
                     </Typography>
                 </Grid>
             </Grid>

--- a/src/pages/tours/[id].tsx
+++ b/src/pages/tours/[id].tsx
@@ -6,7 +6,10 @@ import {Tour} from '../../types/tour'
 import Typography from '@mui/material/Typography'
 import {plainToInstance} from 'class-transformer'
 import ToursService from '../../services/tours/tours-service'
-import {Button, Grid} from '@mui/material'
+import {Divider, Grid, Link as MuiLink} from '@mui/material'
+import Link from 'next/link'
+import EditIcon from '@mui/icons-material/Edit'
+import DeleteIcon from '@mui/icons-material/Delete'
 
 type TourDetailProps = {
     tour: Tour
@@ -33,8 +36,14 @@ const TourDetail = ({tour}: TourDetailProps): JSX.Element => {
         <AppPageLayout>
             <Typography variant="h2" gutterBottom component="div">
                 {tour.name}
+                <Link href={`${tour.id}/edit`} passHref>
+                    <MuiLink><EditIcon/></MuiLink>
+                </Link>
+                <Link href={`${tour.id}/delete`} passHref>
+                    <MuiLink><DeleteIcon/></MuiLink>
+                </Link>
             </Typography>
-            <Grid container mb={2} direction={'row'} spacing={10}>
+            <Grid container mb={2} direction={'row'} spacing={5}>
                 <Grid item>
                     <Typography variant="subtitle1" gutterBottom component="div">
                         Created at: {tour.createdAt.format('DD.MM.YYYY hh:mm')}
@@ -46,7 +55,19 @@ const TourDetail = ({tour}: TourDetailProps): JSX.Element => {
                     </Typography>
                 </Grid>
             </Grid>
-
+            <Divider />
+            <Grid container mb={2} mt={2} direction={'column'}>
+                <Grid item>
+                    <Typography variant="h5" gutterBottom component="div">
+                        Tour description
+                    </Typography>
+                </Grid>
+                <Grid item>
+                    <Typography variant="body1" gutterBottom component="div">
+                        {tour.description}
+                    </Typography>
+                </Grid>
+            </Grid>
         </AppPageLayout>
     )
 }

--- a/src/pages/tours/[id].tsx
+++ b/src/pages/tours/[id].tsx
@@ -1,4 +1,4 @@
-import {NextPageContext} from 'next'
+import {GetServerSideProps} from 'next'
 import {withAuthenticatedOrRedirect} from '../../utils/with-authenticated-or-redirect'
 import {Session} from 'next-auth'
 import AppPageLayout from '../../layouts/app-page-layout'
@@ -10,15 +10,16 @@ import {Divider, Grid, Link as MuiLink} from '@mui/material'
 import Link from 'next/link'
 import EditIcon from '@mui/icons-material/Edit'
 import DeleteIcon from '@mui/icons-material/Delete'
+import {RouteParams} from '../../types/route-params'
 
 type TourDetailProps = {
     tour: Tour
 }
 
-
-export const getServerSideProps = (context: NextPageContext) => withAuthenticatedOrRedirect(context, async (context: NextPageContext, session: Session) => {
+export const getServerSideProps: GetServerSideProps = (context) => withAuthenticatedOrRedirect(context, async (context, session: Session) => {
+    const {id} = context.params as RouteParams
     const service = new ToursService(session)
-    const res = await service.mockOne()
+    const res = await service.mockOne(id)
     const body: Tour = res
 
     return {
@@ -55,7 +56,7 @@ const TourDetail = ({tour}: TourDetailProps): JSX.Element => {
                     </Typography>
                 </Grid>
             </Grid>
-            <Divider />
+            <Divider/>
             <Grid container mb={2} mt={2} direction={'column'}>
                 <Grid item>
                     <Typography variant="h5" gutterBottom component="div">
@@ -63,7 +64,7 @@ const TourDetail = ({tour}: TourDetailProps): JSX.Element => {
                     </Typography>
                 </Grid>
                 <Grid item>
-                    <Typography variant="body1" gutterBottom component="div">
+                    <Typography variant="body1" gutterBottom component="div" whiteSpace={'pre-wrap'}>
                         {tour.description}
                     </Typography>
                 </Grid>

--- a/src/pages/tours/[id].tsx
+++ b/src/pages/tours/[id].tsx
@@ -1,0 +1,59 @@
+import {NextPageContext} from 'next'
+import {withAuthenticatedOrRedirect} from '../../utils/with-authenticated-or-redirect'
+import {Session} from 'next-auth'
+import AppPageLayout from '../../layouts/app-page-layout'
+import {Tour} from '../../types/tour'
+import Typography from '@mui/material/Typography'
+import {plainToInstance} from 'class-transformer'
+import ToursService from '../../services/tours/tours-service'
+import {Button, Grid} from '@mui/material'
+
+type TourDetailProps = {
+    tour: Tour
+}
+
+
+export const getServerSideProps = (context: NextPageContext) => withAuthenticatedOrRedirect(context, async (context: NextPageContext, session: Session) => {
+    const service = new ToursService(session)
+    const res = await service.mockOne()
+    const body: Tour = res
+
+    return {
+        props: {
+            tour: body
+        }
+    }
+})
+
+const TourDetail = ({tour}: TourDetailProps): JSX.Element => {
+    tour = plainToInstance(Tour, tour) // todo: maybe have this in a generic fashion?
+    console.log(tour)
+
+    return (
+        <AppPageLayout>
+            <Typography variant="h2" gutterBottom component="div">
+                {tour.name}
+            </Typography>
+            <Grid container mb={2} direction={'row'} spacing={10}>
+                <Grid item>
+                    <Typography variant="subtitle1" gutterBottom component="div">
+                        Created at: {tour.getFormattedDate()}
+                    </Typography>
+                </Grid>
+                <Grid item>
+                    <Typography variant="subtitle1" gutterBottom component="div">
+                        Created at: {tour.getFormattedDate()}
+                    </Typography>
+                </Grid>
+                <Grid item>
+                    <Typography variant="subtitle1" gutterBottom component="div">
+                        Updated at: {tour.getFormattedDate()}
+                    </Typography>
+                </Grid>
+            </Grid>
+
+        </AppPageLayout>
+    )
+}
+
+export default TourDetail

--- a/src/pages/tours/[id]/edit.tsx
+++ b/src/pages/tours/[id]/edit.tsx
@@ -1,4 +1,4 @@
-import {NextPageContext} from 'next'
+import {GetServerSideProps, NextPageContext} from 'next'
 import {Session} from 'next-auth'
 import Typography from '@mui/material/Typography'
 import {withAuthenticatedOrRedirect} from "../../../utils/with-authenticated-or-redirect";
@@ -7,15 +7,17 @@ import AppPageLayout from "../../../layouts/app-page-layout";
 import TourForm from "../../../components/app/TourForm";
 import ToursService from "../../../services/tours/tours-service";
 import {plainToInstance} from "class-transformer";
+import {RouteParams} from '../../../types/route-params'
 
 type EditTourProps = {
     tour: Tour
 }
 
-export const getServerSideProps = (context: NextPageContext) => withAuthenticatedOrRedirect(context, async (context: NextPageContext, session: Session) => {
-    console.log('param id: ', context.query.id)
+export const getServerSideProps:GetServerSideProps = (context) => withAuthenticatedOrRedirect(context, async (context, session: Session) => {
+    const {id} = context.params as RouteParams
+    console.log('param id: ', id)
     const service = new ToursService(session) // create TourService instance
-    const res = await service.mockOne() // call TourService.getTour(id) property
+    const res = await service.mockOne(id) // call TourService.getTour(id) property
     const body: Tour = res // call res.json()
 
     return {

--- a/src/pages/tours/create.tsx
+++ b/src/pages/tours/create.tsx
@@ -3,9 +3,10 @@ import Typography from "@mui/material/Typography";
 import TourForm from "../../components/app/TourForm";
 import {Tour} from "../../types/tour";
 import {Point} from 'geojson'
+import dayjs from 'dayjs'
 
 const NewTour = () => {
-    const tour: Tour = new Tour("", "", {} as Point, {} as Point, "", new Date(), new Date())
+    const tour: Tour = new Tour("", "", {} as Point, {} as Point, "", dayjs(), dayjs())
 
     return (
         <AppPageLayout>

--- a/src/pages/tours/index.tsx
+++ b/src/pages/tours/index.tsx
@@ -1,4 +1,4 @@
-import {NextPageContext} from 'next'
+import {GetServerSideProps, NextPageContext} from 'next'
 import {withAuthenticatedOrRedirect} from '../../utils/with-authenticated-or-redirect'
 import {Session} from 'next-auth'
 import AppPageLayout from '../../layouts/app-page-layout'
@@ -14,7 +14,7 @@ type AppHomeProps = {
 }
 
 
-export const getServerSideProps = (context: NextPageContext) => withAuthenticatedOrRedirect(context, async (context: NextPageContext, session: Session) => {
+export const getServerSideProps: GetServerSideProps = (context) => withAuthenticatedOrRedirect(context, async (context, session: Session) => {
     const service = new ToursService(session)
     const res = await service.mockAll()
     const body: Tour[] = res // call res.json()

--- a/src/services/tours/tours-service.ts
+++ b/src/services/tours/tours-service.ts
@@ -1,11 +1,18 @@
 import APIService from '../api-service'
 import {Session} from 'next-auth'
 import {Tour} from '../../types/tour'
+import {Dayjs} from 'dayjs'
+
+function loremIpsumGenerator(numberOfParagraphs: number = 1): string {
+    const paragraph = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n\n'
+
+    return paragraph.repeat(numberOfParagraphs)
+}
 
 const serviceResponse: Tour[] = [
     {
         'id': '7eb9cfff-d76f-4421-9064-586cc0511a30',
-        'name': 'test from nest, with user? yes but sabrinas tour now :) ',
+        'name': 'Tour from A to B ',
         'startLocation': {
             'type': 'Point',
             'coordinates': [
@@ -20,13 +27,13 @@ const serviceResponse: Tour[] = [
                 7.920462
             ]
         },
-        'description': 'description from nest',
-        'createdAt': '2020-05-18T18:27:11.887Z' as unknown as Date,
-        'updatedAt': '2005-05-18T18:27:11.887Z' as unknown as Date,
+        'description': loremIpsumGenerator(5),
+        'createdAt': '2020-05-18T18:27:11.887Z' as unknown as Dayjs,
+        'updatedAt': '2005-05-18T18:27:11.887Z' as unknown as Dayjs,
     },
     {
         'id': 'a815f336-1586-4857-a9cc-b521dac7d3c2',
-        'name': 'test from nest, with user? yes but sabrinas tour now :) ',
+        'name': 'Presummer Vibes in Berne',
         'startLocation': {
             'type': 'Point',
             'coordinates': [
@@ -41,13 +48,13 @@ const serviceResponse: Tour[] = [
                 47.328439
             ]
         },
-        'description': 'description from nest',
-        'createdAt': '2022-05-18T18:27:11.887Z' as unknown as Date,
-        'updatedAt': '2022-01-18T18:27:11.887Z' as unknown as Date,
+        'description': loremIpsumGenerator(3),
+        'createdAt': '2022-05-18T18:27:11.887Z' as unknown as Dayjs,
+        'updatedAt': '2022-01-18T18:27:11.887Z' as unknown as Dayjs,
     },
     {
         'id': '48d5f0d1-1f6a-4e63-8968-44f0718c979a',
-        'name': 'test from nest, with user? yes but sabrinas tour now :) ',
+        'name': 'Many nice views above Spiez',
         'startLocation': {
             'type': 'Point',
             'coordinates': [
@@ -62,14 +69,14 @@ const serviceResponse: Tour[] = [
                 47.328439
             ]
         },
-        'description': 'description from nest',
-        'createdAt': '2022-01-18T18:27:11.887Z' as unknown as Date,
-        'updatedAt': '2022-04-18T18:27:11.887Z' as unknown as Date,
+        'description': loremIpsumGenerator(22),
+        'createdAt': '2022-01-18T18:27:11.887Z' as unknown as Dayjs,
+        'updatedAt': '2022-04-18T18:27:11.887Z' as unknown as Dayjs,
     }
 ]
 
 function sleep(ms: number) {
-    return new Promise(resolve => setTimeout(resolve, ms));
+    return new Promise(resolve => setTimeout(resolve, ms))
 }
 
 export default class ToursService extends APIService {
@@ -85,7 +92,8 @@ export default class ToursService extends APIService {
         return serviceResponse
     }
 
-    public async mockOne(): Promise<Tour> {
-        return serviceResponse[0]
+    public async mockOne(id: string): Promise<Tour> {
+        await sleep(150)
+        return serviceResponse.find((tour) => tour.id === id)!
     }
 }

--- a/src/types/route-params.ts
+++ b/src/types/route-params.ts
@@ -1,0 +1,13 @@
+import {ParsedUrlQuery} from 'querystring'
+
+/**
+ * This interface is a workaround for having type-security on dynamic routes with slugs that use [id]. Without it, next
+ * throws typescript errors sind params can be either undefined, a string or an array of strings.
+ *
+ * See https://wallis.dev/blog/nextjs-getstaticprops-and-getstaticpaths-with-typescript
+ *
+ * Todo: check why we need to do it this way and what better options we have.
+ */
+export interface RouteParams extends ParsedUrlQuery {
+    id: string,
+}

--- a/src/types/tour.ts
+++ b/src/types/tour.ts
@@ -1,18 +1,27 @@
 import {Point} from 'geojson'
-import {Type} from 'class-transformer'
+import {Transform, Type} from 'class-transformer'
+import dayjs, {Dayjs} from 'dayjs'
 
 export class Tour {
-    id!: string
-    name!: string
-    startLocation!: Point
-    endLocation!: Point
-    description!: string
+    id: string
+    name: string
+    startLocation: Point
+    endLocation: Point
+    description: string
     @Type(() => Date)
-    createdAt!: Date
+    @Transform(({value}) => dayjs(value), {toClassOnly: true})
+    createdAt: Dayjs
     @Type(() => Date)
-    updatedAt!: Date // todo: make nullable as for create this will not be set
+    @Transform(({value}) => dayjs(value), {toClassOnly: true})
+    updatedAt: Dayjs // todo: make nullable as for create this will not be set
 
-    public getFormattedCreatedAt(): string {
-        return this.createdAt.toLocaleDateString('de-CH') //todo: this should be set according to the users translation settings
+    constructor(id: string, name: string, startLocation: Point, endLocation: Point, description: string, createdAt: Dayjs, updatedAt: Dayjs) {
+        this.id = id
+        this.name = name
+        this.startLocation = startLocation
+        this.endLocation = endLocation
+        this.description = description
+        this.createdAt = createdAt
+        this.updatedAt = updatedAt
     }
 }

--- a/src/types/tour.ts
+++ b/src/types/tour.ts
@@ -2,23 +2,17 @@ import {Point} from 'geojson'
 import {Type} from 'class-transformer'
 
 export class Tour {
-    id: string
-    name: string
-    startLocation: Point
-    endLocation: Point
-    description: string
+    id!: string
+    name!: string
+    startLocation!: Point
+    endLocation!: Point
+    description!: string
     @Type(() => Date)
-    createdAt: Date
+    createdAt!: Date
     @Type(() => Date)
-    updatedAt: Date // todo: make nullable as for create this will not be set
+    updatedAt!: Date // todo: make nullable as for create this will not be set
 
-    constructor(id: string, name: string, startLocation: Point, endLocation: Point, description: string, createdAt: Date, updatedAt: Date) {
-        this.id = id
-        this.name = name
-        this.startLocation = startLocation
-        this.endLocation = endLocation
-        this.description = description
-        this.createdAt = createdAt
-        this.updatedAt = updatedAt
+    public getFormattedCreatedAt(): string {
+        return this.createdAt.toLocaleDateString('de-CH') //todo: this should be set according to the users translation settings
     }
 }

--- a/src/utils/with-authenticated-or-redirect.ts
+++ b/src/utils/with-authenticated-or-redirect.ts
@@ -1,6 +1,7 @@
 import {getSession} from 'next-auth/react'
-import {NextPageContext} from 'next'
+import {GetServerSidePropsContext, NextPageContext, PreviewData} from 'next'
 import {Session} from 'next-auth'
+import {ParsedUrlQuery} from 'querystring'
 
 type PropFunction = {
     props: object
@@ -13,9 +14,9 @@ type PropFunction = {
  * Based on https://github.com/nextauthjs/next-auth/issues/1210#issuecomment-851606553, but fixed and adjusted for
  * typehinting.
  * @param context Current request context
- * @param fn Optional function that returns further props that are merged with the session prop
+ * @param fn? Optional function that returns further props that are merged with the session prop
  */
-export const withAuthenticatedOrRedirect = async (context: NextPageContext, fn?: (context: NextPageContext, session: Session) => Promise<PropFunction>) => {
+export const withAuthenticatedOrRedirect = async (context: GetServerSidePropsContext<ParsedUrlQuery, PreviewData>, fn?: (context: GetServerSidePropsContext<ParsedUrlQuery, PreviewData>, session: Session) => Promise<PropFunction>) => {
     const session = await getSession(context)
     const isUser = !!session?.user
 


### PR DESCRIPTION
Implements #11 

Some things to note:
* I added `dayjs` support because we were happy using it in our todo app. This works nicely with `@Transform` decorators from class-transformer library. **However**, we have to see whether this also works when sending the data to the API. I think we'll just have to use `classToPlain` when sending it back, so that should not be an issue :)
* I fixed the types for our `withAuthenticatedOrRedirect`, because they were wrong. I noticed that when trying to access the `context.params` values as they were not present :) Now, they are properly typehinted and I think we should use `params` and not `query` in `getServerSideProps`, so I changed in the update views as well.
* Notice the interface workaround I had to make - this is a bit ugly, but seems to be the only way to get it working without any hacks (because params can be string, string[] or even undefined 🤷 )