### PR TITLE
Add generic API error handling in preparation for handling errorcodes

### DIFF
--- a/src/components/pages/user/ActivateUser.tsx
+++ b/src/components/pages/user/ActivateUser.tsx
@@ -4,6 +4,7 @@ import useNotifications from '../../../hooks/use-notifications'
 import useApiError from '../../../hooks/use-api-error'
 import AuthService from '../../../services/auth/auth-service'
 import Loader from '../../shared/Loader'
+import Typography from '@mui/material/Typography'
 
 const TourCreate = () => {
   const { userId, token } = useParams()
@@ -27,7 +28,12 @@ const TourCreate = () => {
     activateUser()
   }, [])
 
-  return <Loader></Loader>
+  return <>
+    <Loader></Loader>
+    <Typography component="h1" variant="h2">
+      Activating user...
+    </Typography>
+  </>
 }
 
 export default TourCreate

--- a/src/services/api-service.ts
+++ b/src/services/api-service.ts
@@ -1,4 +1,11 @@
-import { ApiResponseWrapper, ArrayApiResponse, ClassCastHint, RequestBody, SingleApiResponse } from '../types/api'
+import {
+  ApiResponseWrapper,
+  ArrayApiResponse,
+  ClassCastHint,
+  ErrorContent,
+  RequestBody,
+  SingleApiResponse
+} from '../types/api'
 import { plainToInstance } from 'class-transformer'
 
 export default abstract class APIService {
@@ -49,7 +56,7 @@ export default abstract class APIService {
       return { content, ...wrapper }
     }
 
-    return wrapper
+    return this.returnErroneousReponse(wrapper, responseBody)
   }
 
   /**
@@ -72,6 +79,11 @@ export default abstract class APIService {
       return { content, ...wrapper }
     }
 
+    return this.returnErroneousReponse(wrapper, responseBody)
+  }
+
+  private returnErroneousReponse (wrapper: ApiResponseWrapper, { error, message }: ErrorContent): ApiResponseWrapper {
+    wrapper.error = { error, message }
     return wrapper
   }
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,24 +1,49 @@
+/**
+ * Main API Response that contains success state, statuscode and message, and if an error happened, the corresponding
+ * error.
+ */
 export interface ApiResponseWrapper {
   success: boolean
   statusCode: number
   statusMessage: string
+  error?: ErrorContent
 }
 
+/**
+ * Contains an error object that always has an error (e.g. BadRequest) as well as an optional message.
+ */
+export interface ErrorContent {
+  error: string
+  message?: string
+}
+
+/**
+ * Generic API response that returns a single entity (or undefined).
+ */
 export interface SingleApiResponse<T> extends ApiResponseWrapper {
   content?: T
 }
 
+/**
+ * Generic API response that returns an array of entities (or undefined).
+ */
 export interface ArrayApiResponse<T> extends ApiResponseWrapper {
   content?: T[]
 }
 
+/**
+ * Helper type that can be used to typehint a class object.
+ */
 export type ClassCastHint<T> = (new (...args: any[]) => T) | void
 
+/**
+ * Basic request body that is sent to the backend.
+ */
 export interface RequestBody {
   headers: {
     'Content-Type': string
     'Authorization'?: string
   };
-  method: string;
-  body?: string;
+  method: string
+  body?: string
 }


### PR DESCRIPTION
I noticed that we only show the errorcode when something happens, e.g. the snackbar shows "BadRequest". This is because we do not throw error messages in the backend.

In preparation for this, I adjusted the errorhandling mechanism so we always get the actual error object. If we now start to throw error messages in the backend (e.g. `throw new BadRequestException('somethings happened')`), the snackbar will show the message (or fallback to the basic error).

We can use this to throw (translatable?) error messages, which would be a nice (and quick!) feature.