### PR TITLE
Feature/renew token

### DIFF
--- a/__tests__/unit/services/api-service.test.ts
+++ b/__tests__/unit/services/api-service.test.ts
@@ -9,7 +9,7 @@ import { RequestBody } from '../../../src/types/api'
 class ApiServiceWrapper extends APIService {
   constructor (accessToken?: string) {
     super()
-    this.token = accessToken
+    this.accessToken = accessToken
   }
 
   getRequestUrl (prefix: string, endpoint: string): string {

--- a/__tests__/unit/services/auth-service.test.ts
+++ b/__tests__/unit/services/auth-service.test.ts
@@ -31,7 +31,7 @@ describe('AuthService', () => {
 
   it('calls API and returns the response as JSON', async () => {
     const service = new AuthService()
-    const mockResponse = { access_token: mockedToken }
+    const mockResponse = { accessToken: mockedToken }
     fetchMock.mockResponseOnce(JSON.stringify(mockResponse))
     const result = await service.login(mockUser, mockPassword)
 

--- a/__tests__/unit/utils/token-needs-refresh.ts
+++ b/__tests__/unit/utils/token-needs-refresh.ts
@@ -1,0 +1,34 @@
+import '@testing-library/jest-dom'
+import dayjs from 'dayjs'
+import { JwtToken } from '../../../src/types/jwt-token'
+import tokenNeedsRefresh from '../../../src/utils/token-needs-refresh'
+
+describe('tokenNeedsRefresh', () => {
+  it('returns true if token is below 5 minutes of validity', () => {
+    const date = dayjs().add(4, 'minutes')
+    const mockToken = { exp: date.toDate().getTime() / 1000 } as JwtToken
+
+    expect(tokenNeedsRefresh(mockToken)).toEqual(true)
+  })
+
+  it('returns true if token expiration is in the past', () => {
+    const date = dayjs().subtract(4, 'minutes')
+    const mockToken = { exp: date.toDate().getTime() / 1000 } as JwtToken
+
+    expect(tokenNeedsRefresh(mockToken)).toEqual(true)
+  })
+
+  it('returns false if token is of 5 minutes of validity', () => {
+    const date = dayjs().add(5, 'minutes')
+    const mockToken = { exp: date.toDate().getTime() / 1000 } as JwtToken
+
+    expect(tokenNeedsRefresh(mockToken)).toEqual(false)
+  })
+
+  it('returns false if token is in the future', () => {
+    const date = dayjs().add(5, 'days')
+    const mockToken = { exp: date.toDate().getTime() / 1000 } as JwtToken
+
+    expect(tokenNeedsRefresh(mockToken)).toEqual(false)
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "jest": "^28.1.0",
         "jest-environment-jsdom": "^28.1.0",
         "jest-fetch-mock": "^3.0.3",
+        "mockdate": "^3.0.5",
         "msw": "^0.35.0",
         "react-router-dom": "^6.3.0",
         "react-test-renderer": "^18.1.0",
@@ -15933,6 +15934,12 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/mockdate": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/mockdate/-/mockdate-3.0.5.tgz",
+      "integrity": "sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==",
+      "dev": true
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -34104,6 +34111,12 @@
       "requires": {
         "minimist": "^1.2.6"
       }
+    },
+    "mockdate": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/mockdate/-/mockdate-3.0.5.tgz",
+      "integrity": "sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==",
+      "dev": true
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "jest": "^28.1.0",
     "jest-environment-jsdom": "^28.1.0",
     "jest-fetch-mock": "^3.0.3",
+    "mockdate": "^3.0.5",
     "msw": "^0.35.0",
     "react-router-dom": "^6.3.0",
     "react-test-renderer": "^18.1.0",

--- a/src/enums/local-storage-key.ts
+++ b/src/enums/local-storage-key.ts
@@ -2,8 +2,9 @@
  * This enum holds all storage keys that are used throughout the app.
  */
 export enum LocalStorageKey {
-    UserSession = 'UserSession',
-    ActiveStyle = 'active_style',
-    LightMode = 'light',
-    DarkMode = 'dark',
+  AccessToken = 'AccessToken',
+  RefreshToken = 'RefreshToken',
+  ActiveStyle = 'active_style',
+  LightMode = 'light',
+  DarkMode = 'dark',
 }

--- a/src/hooks/use-interval.ts
+++ b/src/hooks/use-interval.ts
@@ -1,0 +1,30 @@
+import { useEffect, useRef } from 'react'
+
+/**
+ * Creates a reusable interval timer as a hook. Does so by assigning the callback to a mutable Ref and handling the
+ * clearing of setInterval()
+ * @param callback
+ * @param delay
+ */
+const useInterval = (callback: CallableFunction, delay: number) => {
+  const savedCallback = useRef<CallableFunction>()
+
+  useEffect(() => {
+    savedCallback.current = callback
+  }, [callback])
+
+  useEffect(() => {
+    function tick () {
+      if (savedCallback.current) {
+        savedCallback.current()
+      }
+    }
+
+    if (delay !== null) {
+      const id = setInterval(tick, delay)
+      return () => clearInterval(id)
+    }
+  }, [delay])
+}
+
+export default useInterval

--- a/src/services/api-service.ts
+++ b/src/services/api-service.ts
@@ -9,7 +9,7 @@ import {
 import { plainToInstance } from 'class-transformer'
 
 export default abstract class APIService {
-  protected token?: string = undefined
+  protected accessToken?: string = undefined
   private baseUrl: string = process.env.REACT_APP_PUBLIC_BACKEND_API || 'http://localhost:3000'
 
   protected getRequestUrl (prefix: string, endpoint?: string): string {
@@ -17,7 +17,7 @@ export default abstract class APIService {
     return endpoint ? `${baseUrl}/${endpoint}` : baseUrl
   }
 
-  protected getRequestBody (method: 'GET' | 'POST' | 'PATCH' | 'DELETE', body?: any): RequestBody {
+  protected getRequestBody (method: 'GET' | 'POST' | 'PATCH' | 'DELETE', body?: any, overrideTokenHeader?: string): RequestBody {
     const requestBody: RequestBody = {
       method,
       headers: {
@@ -29,8 +29,9 @@ export default abstract class APIService {
       requestBody.body = body ? JSON.stringify(body) : ''
     }
 
-    if (this.token) {
-      requestBody.headers = { ...requestBody.headers, Authorization: this.extractBearerTokenFromSession() }
+    const useAuthHeader = overrideTokenHeader || this.accessToken
+    if (useAuthHeader) {
+      requestBody.headers = { ...requestBody.headers, Authorization: this.extractBearerTokenFromSession(useAuthHeader) }
     }
 
     return requestBody
@@ -122,7 +123,7 @@ export default abstract class APIService {
     }
   }
 
-  private extractBearerTokenFromSession (): string {
-    return `Bearer ${this.token}`
+  private extractBearerTokenFromSession (token: string): string {
+    return `Bearer ${token}`
   }
 }

--- a/src/services/auth/auth-service.ts
+++ b/src/services/auth/auth-service.ts
@@ -1,20 +1,20 @@
 import APIService from '../api-service'
-import LocalStorageService from '../local-storage-service'
-import { LocalStorageKey } from '../../enums/local-storage-key'
 import { AuthObject } from '../../types/auth'
 import { SingleApiResponse } from '../../types/api'
 
 export default class AuthService extends APIService {
   private prefix: string = 'auth'
-  private localStorageService: LocalStorageService = new LocalStorageService()
 
   public async login (email: string, password: string): Promise<SingleApiResponse<AuthObject>> {
     return await this.sendLoginRequest(email, password)
   }
 
-  public async logout (): Promise<void> {
-    // todo: call api endpoint
-    this.localStorageService.removeItem(LocalStorageKey.UserSession)
+  public async refreshTokens (refreshToken: string): Promise<SingleApiResponse<AuthObject>> {
+    return this.fetchSingleDataFromApi(
+      this.getRequestUrl(this.prefix, 'refresh'),
+      this.getRequestBody('POST', null, refreshToken),
+      AuthObject
+    )
   }
 
   public async activateUser (userId: string, token: string): Promise<SingleApiResponse<void>> {

--- a/src/services/tours/tours-service.ts
+++ b/src/services/tours/tours-service.ts
@@ -7,7 +7,7 @@ export default class ToursService extends APIService {
 
   constructor (token: string | undefined) {
     super()
-    this.token = token
+    this.accessToken = token
   }
 
   public async findAll (): Promise<ArrayApiResponse<Tour>> {

--- a/src/services/users/users-service.ts
+++ b/src/services/users/users-service.ts
@@ -5,7 +5,7 @@ export default class UsersService extends APIService {
 
   constructor (token: string | any) {
     super()
-    this.token = token
+    this.accessToken = token
   }
 
   public async profile (): Promise<Response> {

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,8 +1,44 @@
-/* eslint-disable camelcase */
 export class AuthObject {
-  access_token: string
+  accessToken: string
+  refreshToken: string
 
-  constructor (access_token: string) {
-    this.access_token = access_token
+  constructor (accessToken: string, refreshToken: string) {
+    this.accessToken = accessToken
+    this.refreshToken = refreshToken
   }
+}
+
+/**
+ * Basic JwtTokenPayload that is part of all JWTs.
+ */
+interface JwtTokenPayloadBase {
+  iat: number;
+  exp: number;
+}
+
+/**
+ * In tokens, this UserIdentifier is the payload.
+ */
+export interface UserIdentifier {
+  sub: string;
+  email: string;
+}
+
+/**
+ * In tokens, this SessionIdentifier is the payload.
+ */
+export interface SessionIdentifier {
+  sessionId: string;
+}
+
+/**
+ * RefreshToken contains a session ID that maps to a UserSession object.
+ */
+export interface RefreshToken extends JwtTokenPayloadBase, SessionIdentifier {
+}
+
+/**
+ * The main authtoken.
+ */
+export interface AccessToken extends JwtTokenPayloadBase, UserIdentifier {
 }

--- a/src/utils/token-needs-refresh.ts
+++ b/src/utils/token-needs-refresh.ts
@@ -1,0 +1,16 @@
+import { JwtToken } from '../types/jwt-token'
+import dayjs from 'dayjs'
+
+/**
+ * Checks whether a given JwtToken is within 5 minutes of expiry.
+ * @param token
+ */
+const tokenNeedsRefresh: (token: JwtToken) => (boolean) = (token: JwtToken) => {
+  const { exp } = token
+  const expiryDate = dayjs.unix(exp)
+  const currentDate = dayjs()
+
+  return expiryDate.diff(currentDate, 'minutes') < 5
+}
+
+export default tokenNeedsRefresh

--- a/src/utils/token-needs-refresh.ts
+++ b/src/utils/token-needs-refresh.ts
@@ -9,7 +9,6 @@ const tokenNeedsRefresh: (token: JwtToken) => (boolean) = (token: JwtToken) => {
   const { exp } = token
   const expiryDate = dayjs.unix(exp)
   const currentDate = dayjs()
-
   return expiryDate.diff(currentDate, 'minutes') < 5
 }
 


### PR DESCRIPTION
This implements #45.

Adds an interval and the whole logic for refreshing, setting and unsetting the code. We can still debate whether we need a logout endpoint in the API, but I feel we don't.

For more information -> see backend (because it was a bit more than just adding the hook XD)

For the backend: see https://github.com/gipfeli-io/gipfeli-api/pull/47