### PR TITLE
Remove navigator.online usage and add working check for network connection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,6 @@ REACT_APP_PUBLIC_BACKEND_API= # optional - looks for API on port 3000 localhost 
 # Sentry config - if left empty, sentry is not initialized (e.g. for development purposes)
 REACT_APP_SENTRY_DSN=
 REACT_APP_SENTRY_ENVIRONMENT=   # used to distinguish the environment - defaults to localhost if not set
+
+# Configure polling interval for checking if app is online
+ONLINE_POLLING_DELAY = # optional - will set polling to 60000ms (1 Minute) if not set

--- a/src/components/providers/OnlineStatusProvider.tsx
+++ b/src/components/providers/OnlineStatusProvider.tsx
@@ -1,18 +1,26 @@
-import React, { PropsWithChildren, useEffect, useState } from 'react'
+import React, { PropsWithChildren, useState } from 'react'
 import OnlineStatusContext from '../../contexts/online-status-context'
+import useInterval from '../../hooks/use-interval'
 
 export const OnlineStatusProvider = ({ children }: PropsWithChildren<any>) => {
   const [onlineStatus, setOnlineStatus] = useState<boolean>(true)
+  const requestUrl: string = process.env.REACT_APP_PUBLIC_BACKEND_API || 'http://localhost:3000'
+  const pollingDelay: string | number = process.env.ONLINE_POLLING_DELAY || 60000
 
-  useEffect(() => {
-    window.addEventListener('offline', () => setOnlineStatus(false))
-    window.addEventListener('online', () => setOnlineStatus(true))
-
-    return () => {
-      window.removeEventListener('offline', () => setOnlineStatus(false))
-      window.removeEventListener('online', () => setOnlineStatus(true))
+  const checkOnlineStatus = async (): Promise<void> => {
+    try {
+      const request = await fetch(requestUrl + '/robots.txt')
+      if (request.status < 500) {
+        setOnlineStatus(true)
+      } else {
+        setOnlineStatus(false)
+      }
+    } catch (error) {
+      setOnlineStatus(false)
     }
-  }, [])
+  }
+
+  useInterval(checkOnlineStatus, +pollingDelay)
 
   return (
     <OnlineStatusContext.Provider value={onlineStatus}>


### PR DESCRIPTION
Navigator.online will not really check if the user has internet. It will only check if the user is connected to a network and it will show that the user is online even though the network has no internet connection. 
The only possible way to really check the network connection is by trying to fetch a resource. So I implemented an interval that checks every X minutes if it can get the robots.txt from our api. If status code 500 is returned it will trigger the offline banner and tell the user that he is offline.