### PR TITLE
Fix ignored polling delay variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ REACT_APP_SENTRY_DSN=
 REACT_APP_SENTRY_ENVIRONMENT=   # used to distinguish the environment - defaults to localhost if not set
 
 # Configure polling interval for checking if app is online
-ONLINE_POLLING_DELAY = # optional - will set polling to 60000ms (1 Minute) if not set
+REACT_APP_ONLINE_POLLING_DELAY = # optional - will set polling to 20000ms (20 seconds) if not set
 
 # Storage Bucket URL, with trailing slash
 REACT_APP_STORAGE_BUCKET_BASE_URL=

--- a/src/components/providers/OnlineStatusProvider.tsx
+++ b/src/components/providers/OnlineStatusProvider.tsx
@@ -8,7 +8,7 @@ export const OnlineStatusProvider = ({ children }: PropsWithChildren<any>) => {
   const [onlineStatus, setOnlineStatus] = useState<boolean>(true)
   const auth = useAuth()
   const requestUrl: string = process.env.REACT_APP_PUBLIC_BACKEND_API || 'http://localhost:3000'
-  const pollingDelay: string | number = process.env.ONLINE_POLLING_DELAY || 20000
+  const pollingDelay: string | number = process.env.REACT_APP_ONLINE_POLLING_DELAY || 20000
   const tourSyncService: ToursSyncService = new ToursSyncService(auth.token)
 
   const checkOnlineStatus = async (): Promise<void> => {


### PR DESCRIPTION
This fixes the polling delay setting. Only environment variables prefixed with `REACT_APP_` are available in react builds (see https://create-react-app.dev/docs/adding-custom-environment-variables/).

I also adjusted the naming, because the default was 20000, not 60000.