### PR TITLE
Add tests

### DIFF
--- a/__mocks__/fileMock.js
+++ b/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';

--- a/__tests__/unit/services/map-configuration-service.test.ts
+++ b/__tests__/unit/services/map-configuration-service.test.ts
@@ -1,0 +1,101 @@
+import MapConfigurationService from '../../../src/services/map/map-configuration-service'
+import { MarkerSize } from '../../../src/enums/marker-size'
+import { FeatureLike } from 'ol/Feature'
+
+jest.mock('../../../src/static/img/map/pin_start_of_tour.png')
+
+/**
+ * Note that we do not check for the actual images, because we can just "generally" mock images with our fileMock, not
+ * specific images. However, if the image would fail, openlayers would throw an error, so we can check for sizes and
+ * other props.
+ *
+ * As for the caching, we use expect(a).toBe(b), which does a referential integrity check. So we compare two instances
+ * and check whether they are the same instance, and not just two instances with equal properties.
+ */
+describe('MapConfigurationService', () => {
+  describe('getStartIcon', () => {
+    it('returns properly sized icon', () => {
+      const result = MapConfigurationService.getStartIcon()
+      expect(result.getImage().getScale()).toEqual(MarkerSize.DEFAULT)
+    })
+
+    it('uses the cache if requested more than once', () => {
+      const result = MapConfigurationService.getStartIcon()
+      const resultTwo = MapConfigurationService.getStartIcon()
+
+      expect(result).toBe(resultTwo)
+    })
+  })
+
+  describe('getEndIcon', () => {
+    it('returns properly sized icon', () => {
+      const result = MapConfigurationService.getEndIcon()
+      expect(result.getImage().getScale()).toEqual(MarkerSize.DEFAULT)
+    })
+
+    it('uses the cache if requested more than once', () => {
+      const result = MapConfigurationService.getEndIcon()
+      const resultTwo = MapConfigurationService.getEndIcon()
+
+      expect(result).toBe(resultTwo)
+    })
+  })
+
+  describe('getBasicGpsImageIcon', () => {
+    it('returns the same icon if it is a feature or undefined, and a different if it is a cluster', () => {
+      // Since we cannot test the actual images that are returned, we just check whether empty returns the same from
+      // cache. To do this, we mock a FeatureLike and its get() method, which returns an array. If it has two or more
+      // objects, we mimick a cluster.
+      const mockFeature: FeatureLike = { get: () => ['mock'] } as unknown as FeatureLike
+      const mockCluster: FeatureLike = { get: () => ['mock', 'mock'] } as unknown as FeatureLike
+      const result = MapConfigurationService.getBasicGpsImageIcon(mockFeature)
+      const resultTwo = MapConfigurationService.getBasicGpsImageIcon()
+      const resultCluster = MapConfigurationService.getBasicGpsImageIcon(mockCluster)
+
+      expect(result.getImage().getScale()).toEqual(MarkerSize.DEFAULT)
+      expect(result).toBe(resultTwo)
+      expect(result).not.toBe(resultCluster)
+    })
+
+    it('uses the cache if requested more than once', () => {
+      const result = MapConfigurationService.getBasicGpsImageIcon()
+      const resultTwo = MapConfigurationService.getBasicGpsImageIcon()
+
+      expect(result).toBe(resultTwo)
+    })
+  })
+
+  describe('getGpsImageIconWithinCluster', () => {
+    it('returns properly sized icon', () => {
+      const result = MapConfigurationService.getGpsImageIconWithinCluster()
+      expect(result.getImage().getScale()).toEqual(MarkerSize.CLUSTERED)
+    })
+
+    it('uses the cache if requested more than once', () => {
+      const result = MapConfigurationService.getGpsImageIconWithinCluster()
+      const resultTwo = MapConfigurationService.getGpsImageIconWithinCluster()
+
+      expect(result).toBe(resultTwo)
+    })
+  })
+
+  describe('getSelectedGpsImageIcon', () => {
+    it('returns properly sized icons depending on whether it is a  cluster or not', () => {
+      const mockFeature: FeatureLike = { get: () => ['mock'] } as unknown as FeatureLike
+      const mockCluster: FeatureLike = { get: () => ['mock', 'mock'] } as unknown as FeatureLike
+      const resultFeature = MapConfigurationService.getSelectedGpsImageIcon(mockFeature)
+      const resultCluster = MapConfigurationService.getSelectedGpsImageIcon(mockCluster)
+
+      expect(resultFeature.getImage().getScale()).toEqual(MarkerSize.SELECTED)
+      expect(resultCluster.getImage().getScale()).toEqual(MarkerSize.DEFAULT)
+    })
+
+    it('uses the cache if requested more than once', () => {
+      const mockFeature: FeatureLike = { get: () => ['mock'] } as unknown as FeatureLike
+      const result = MapConfigurationService.getSelectedGpsImageIcon(mockFeature)
+      const resultTwo = MapConfigurationService.getSelectedGpsImageIcon(mockFeature)
+
+      expect(result).toBe(resultTwo)
+    })
+  })
+})

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,7 +17,8 @@ const customJestConfig = {
      * See https://stackoverflow.com/a/59283057
      */
   moduleNameMapper: {
-    '\\.(css|less|scss|sass|png)$': 'identity-obj-proxy'
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
+    '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': '<rootDir>/__mocks__/fileMock.js'
   }
 }
 

--- a/src/components/shared/map/layers/GpsImageMarkerLayer.tsx
+++ b/src/components/shared/map/layers/GpsImageMarkerLayer.tsx
@@ -3,7 +3,6 @@ import MapContext from '../MapContext'
 import VectorSource from 'ol/source/Vector'
 import VectorLayer from 'ol/layer/Vector'
 import { GeoJsonPropertySetter, StyleSelector } from '../../../../types/map'
-import { Icon, Style } from 'ol/style'
 import 'ol-ext/dist/ol-ext.css'
 import './styles/gps-image-popup.scss'
 import { ImageUpload } from '../../../../types/media'
@@ -34,12 +33,7 @@ const GpsImageMarkerLayer = ({ features }: GpsMarkerLayerProps) => {
   const { map } = useContext(MapContext)
 
   const iconSelector: StyleSelector<ImageUpload> = (_index, _objects) => {
-    return new Style({
-      image: new Icon(({
-        anchor: [0.5, 1],
-        src: MapConfigurationService.getImageIcon()
-      }))
-    })
+    return MapConfigurationService.getBasicGpsImageIcon()
   }
 
   const propertySetter: GeoJsonPropertySetter<ImageUpload, PopupContent> = (feature: ImageUpload) => {
@@ -93,7 +87,7 @@ const GpsImageMarkerLayer = ({ features }: GpsMarkerLayerProps) => {
       map.addInteraction(select)
 
       select.getFeatures().on('add', function (e: BaseEvent | Event): void {
-      // Somehow, the typings of OL are wrong. We get a CollectionEvent here, which is neither BaseEvent nor Event...
+        // Somehow, the typings of OL are wrong. We get a CollectionEvent here, which is neither BaseEvent nor Event...
         const castedEvent = e as CollectionEvent
         const selectedFeatures = castedEvent.element.get('features')
 
@@ -115,8 +109,8 @@ const GpsImageMarkerLayer = ({ features }: GpsMarkerLayerProps) => {
     const selectListener = setupPopups(selectableLayer)
 
     return () => {
-    // Clean up, because in devmode, the select listener is attached twice, opening 2 popups.
-    // todo: maybe we should clean up everything?
+      // Clean up, because in devmode, the select listener is attached twice, opening 2 popups.
+      // todo: maybe we should clean up everything?
       map.removeInteraction(selectListener)
     }
   }, [map, features])

--- a/src/enums/marker-size.ts
+++ b/src/enums/marker-size.ts
@@ -1,0 +1,8 @@
+/**
+ * Sizes the mapmarkers may take.
+ */
+export enum MarkerSize {
+  DEFAULT = 1.0,
+  SELECTED = 1.2,
+  CLUSTERED = 0.9
+}

--- a/src/services/map/map-configuration-service.ts
+++ b/src/services/map/map-configuration-service.ts
@@ -5,6 +5,7 @@ import pinMultiple from '../../static/img/map/pin_cluster.png' // Source: https:
 import pinDefault from '../../static/img/map/pin_default.png' // Source: https://cdn.mapmarker.io/api/v1/font-awesome/v5/pin?icon=fa-globe&size=50&hoffset=0&voffset=-1
 import { FeatureLike } from 'ol/Feature'
 import { Icon, Stroke, Style } from 'ol/style'
+import { MarkerSize } from '../../enums/marker-size'
 
 enum StyleCache {
   WAYPOINT_START,
@@ -14,12 +15,6 @@ enum StyleCache {
   IMAGE_WITHIN_CLUSTER,
   SELECTED_IMAGE,
   SELECTED_CLUSTER
-}
-
-enum MarkerSize {
-  DEFAULT = 1.0,
-  SELECTED = 1.2,
-  CLUSTERED = 0.9
 }
 
 /**
@@ -68,13 +63,6 @@ export default class MapConfigurationService {
   }
 
   /**
-   * Icon used for images with GPS coordinates.
-   */
-  public static getImageIcon (): string {
-    return pinImage
-  }
-
-  /**
    * Defines the maximum number of markers which can be added manually.
    */
   public static getMaxMarkerCount (): number {
@@ -83,11 +71,17 @@ export default class MapConfigurationService {
 
   /**
    * Returns the style for a marker on the image layer. If the given feature contains more than one feature, it means
-   * that we have a clustered marker, so we return a different icon (see comment below on getSelectedGpsImageIcon)
+   * that we have a clustered marker, so we return a different icon (see comment below on getSelectedGpsImageIcon).
+   *
+   * If no feature is given, it just returns the basic image picture (meaning it's no cluster).
+   *
    * @param clusterFeatures
    */
-  public static getBasicGpsImageIcon (clusterFeatures: FeatureLike): Style {
-    const isCluster = clusterFeatures.get('features').length > 1
+  public static getBasicGpsImageIcon (clusterFeatures?: FeatureLike): Style {
+    const isCluster = clusterFeatures === undefined
+      ? false
+      : clusterFeatures.get('features').length > 1
+
     const [iconType, iconSrc] = isCluster
       ? [StyleCache.BASIC_CLUSTER, pinMultiple]
       : [StyleCache.BASIC_IMAGE, pinImage]
@@ -114,7 +108,7 @@ export default class MapConfigurationService {
       return new Style({
         image: new Icon(({
           anchor: [0.5, 1],
-          src: MapConfigurationService.getImageIcon(),
+          src: pinImage,
           scale: MarkerSize.CLUSTERED
         })),
         stroke: new Stroke({


### PR DESCRIPTION
Closes #81.

The tests are somewhat ugly, but there's no better way, because we'd have to mock the file contents which we can't. However, we can test some of the functionality and the caching mechanism.