### PR TITLE
Add offline auth token handling

### DIFF
--- a/src/components/pages/Login.tsx
+++ b/src/components/pages/Login.tsx
@@ -10,11 +10,9 @@ import AuthFormLinks from '../shared/AuthFormLinks'
 const Login = () => {
   const navigate = useNavigate()
   const auth = useAuth()
-
   const login = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     const data = new FormData(event.currentTarget)
-    // todo: handle error
     await auth.signIn(
       data.get('email')!.toString(),
       data.get('password')!.toString(),

--- a/src/enums/local-storage-key.ts
+++ b/src/enums/local-storage-key.ts
@@ -9,6 +9,5 @@ export enum LocalStorageKey {
   DarkMode = 'dark',
   ConnectionStatus = 'connection_status',
   IsGoOnlineButtonVisible = 'IsGoOnlineButtonVisible',
-  IsOnlineBannerVisible = 'IsOnlineBannerVisible',
-  SessionExpirationMessageShown = 'SessionExpirationMessageShown'
+  IsOnlineBannerVisible = 'IsOnlineBannerVisible'
 }

--- a/src/enums/local-storage-key.ts
+++ b/src/enums/local-storage-key.ts
@@ -9,5 +9,6 @@ export enum LocalStorageKey {
   DarkMode = 'dark',
   ConnectionStatus = 'connection_status',
   IsGoOnlineButtonVisible = 'IsGoOnlineButtonVisible',
-  IsOnlineBannerVisible = 'IsOnlineBannerVisible'
+  IsOnlineBannerVisible = 'IsOnlineBannerVisible',
+  SessionExpirationMessageShown = 'SessionExpirationMessageShown'
 }

--- a/src/types/contexts.ts
+++ b/src/types/contexts.ts
@@ -16,7 +16,7 @@ export interface AuthenticationContextType {
   email: string | undefined
   isAdmin: boolean
   token: string | undefined
-  signIn: (email: string, password: string, callback: () => void) => void
+  signIn: (email: string, password: string, callback: () => void) => Promise<void>
   signOut: (callback: () => void) => void
 }
 

--- a/src/utils/token-needs-refresh.ts
+++ b/src/utils/token-needs-refresh.ts
@@ -4,12 +4,14 @@ import dayjs from 'dayjs'
 /**
  * Checks whether a given JwtToken is within 5 minutes of expiry.
  * @param token
+ * @param expiryDiff
  */
-const tokenNeedsRefresh: (token: JwtToken) => (boolean) = (token: JwtToken) => {
+const tokenNeedsRefresh: (token: JwtToken, expiryDiff?: number) => (boolean) = (token: JwtToken, expiryDiff?: number) => {
   const { exp } = token
   const expiryDate = dayjs.unix(exp)
   const currentDate = dayjs()
-  return expiryDate.diff(currentDate, 'minutes') < 5
+  const diff = expiryDiff || 5
+  return expiryDate.diff(currentDate, 'minutes') < diff
 }
 
 export default tokenNeedsRefresh


### PR DESCRIPTION
I decided that it makes the most sense to not check the token if the user is using the app in offline mode. In most of the cases we will not have an internet connection and cannot refresh or check the token validity. And even if the user has internet connection but decides to keep using the app in offline mode it does not make sense to check the token then. 
If the user at one point was able to login and then puts the app into offline mode we simply have to trust that the login is valid even after a few weeks. We could add some logic that extends the validity of the token as soon as the users goes into offline mode but it doesn't really make sense as issuing a token is the responsibility of our backend and we also don't want to duplicate any code.
As soon as the users goes online again the token check is re-activated and if the session is not valid anymore the user will be logged out. So I think this solution is fine. :) 