### PR TITLE
Add error handling for dexie

### DIFF
--- a/src/components/pages/tours/TourCreate.tsx
+++ b/src/components/pages/tours/TourCreate.tsx
@@ -63,8 +63,10 @@ const TourCreate = () => {
       const result = await localDatabaseService.create(tourToSave)
       if (result) {
         triggerSuccess(result.toString())
+      } else {
+        const errorResponse = localDatabaseService.getErrorResponse(false, 500, `Could not create local tour. ${result}`)
+        throwError(errorResponse)
       }
-      // todo throwDexieError
     } else {
       const data = await toursService.create(tourToSave)
       if (data.success) {

--- a/src/components/pages/tours/TourDetail.tsx
+++ b/src/components/pages/tours/TourDetail.tsx
@@ -40,7 +40,7 @@ const TourDetail = () => {
       if (localTour) {
         setTour(localTour)
       } else {
-        console.log('tour-detail::error fetching tour') // todo: throw error
+        throwError(localDatabaseService.getTourNotFoundResponse())
       }
     }
     async function fetchTour () {

--- a/src/components/pages/tours/TourDetail.tsx
+++ b/src/components/pages/tours/TourDetail.tsx
@@ -21,6 +21,7 @@ import { TourStatusType } from '../../../enums/tour-status-type'
 import { formatDate } from '../../../utils/date-conversion-helper'
 import DeleteConfirmation from '../../shared/confirmation/DeleteConfirmation'
 import useCheckConnection from '../../../hooks/use-check-connection'
+import useErrorHandling from '../../../hooks/use-error-handling'
 
 const TourDetail = () => {
   const navigate = useNavigate()
@@ -33,6 +34,7 @@ const TourDetail = () => {
   const throwError = useApiError()
   const { isOffline } = useConnectionStatus()
   const checkConnection = useCheckConnection()
+  const { triggerError } = useErrorHandling()
   const localDatabaseService = new LocalDatabaseService(auth.token)
 
   useEffect(() => {
@@ -44,19 +46,23 @@ const TourDetail = () => {
       }
     }
     async function fetchTour () {
-      const localTour = await localDatabaseService.getOne(id)
-      if (isOffline()) {
-        setLocalTour(localTour)
-      } else if (localTour?.status === TourStatusType.CREATED) {
-        setLocalTour(localTour)
-        checkConnection()
-      } else {
-        const data = await service.findOne(id)
-        if (data.success) {
-          setTour(data.content)
+      try {
+        const localTour = await localDatabaseService.getOne(id)
+        if (isOffline()) {
+          setLocalTour(localTour)
+        } else if (localTour?.status === TourStatusType.CREATED) {
+          setLocalTour(localTour)
+          checkConnection()
         } else {
-          throwError(data)
+          const data = await service.findOne(id)
+          if (data.success) {
+            setTour(data.content)
+          } else {
+            throwError(data)
+          }
         }
+      } catch (error: unknown) {
+        triggerError(error as Error)
       }
     }
     fetchTour()

--- a/src/components/pages/tours/TourEdit.tsx
+++ b/src/components/pages/tours/TourEdit.tsx
@@ -50,7 +50,7 @@ const EditTour = () => {
         if (localTour) {
           setResult(localTour)
         } else {
-          console.log('tour-edit::error fetching tour') // todo: throw error
+          throwError(localDatabaseService.getTourNotFoundResponse())
         }
       } else {
         const data = await toursService.findOne(id)
@@ -84,7 +84,8 @@ const EditTour = () => {
       if (result) {
         triggerSuccess()
       } else {
-        console.log('tour-edit::error while editing') // todo add error handling
+        const errorResponse = localDatabaseService.getErrorResponse(false, 500, 'Could not edit local tour')
+        throwError(errorResponse)
       }
     } else {
       if (baseTour.status === TourStatusType.CREATED) {

--- a/src/components/pages/tours/ToursOverview.tsx
+++ b/src/components/pages/tours/ToursOverview.tsx
@@ -14,6 +14,7 @@ import LocalDatabaseService from '../../../services/local-database-service'
 import { TourStatusType } from '../../../enums/tour-status-type'
 import ListContext from '../../shared/list/ListContext'
 import DeleteConfirmation from '../../shared/confirmation/DeleteConfirmation'
+import useErrorHandling from '../../../hooks/use-error-handling'
 
 const ToursOverview = () => {
   const { token } = useAuth()
@@ -25,22 +26,27 @@ const ToursOverview = () => {
   const [loading, setLoading] = useState<boolean>(true)
   const throwError = useApiError()
   const { isOffline } = useConnectionStatus()
+  const { triggerError } = useErrorHandling()
   const localDatabaseService = new LocalDatabaseService(token)
 
   useEffect(() => {
     async function fetchTours () {
-      if (isOffline()) {
-        const tours = await localDatabaseService.findAllTours()
-        setTourList(tours)
-        setLoading(false)
-      } else {
-        const data = await service.findAll()
-        if (data.success) {
-          setTourList(data.content!)
+      try {
+        if (isOffline()) {
+          const tours = await localDatabaseService.findAllTours()
+          setTourList(tours)
+          setLoading(false)
         } else {
-          throwError(data)
+          const data = await service.findAll()
+          if (data.success) {
+            setTourList(data.content!)
+          } else {
+            throwError(data)
+          }
+          setLoading(false)
         }
-        setLoading(false)
+      } catch (error: unknown) {
+        triggerError(error as Error)
       }
     }
 

--- a/src/components/pages/tours/ToursOverview.tsx
+++ b/src/components/pages/tours/ToursOverview.tsx
@@ -30,7 +30,7 @@ const ToursOverview = () => {
   useEffect(() => {
     async function fetchTours () {
       if (isOffline()) {
-        const tours = await localDatabaseService.findAllTours() // todo: handle dexie error
+        const tours = await localDatabaseService.findAllTours()
         setTourList(tours)
         setLoading(false)
       } else {

--- a/src/components/shared/ErrorBoundary.tsx
+++ b/src/components/shared/ErrorBoundary.tsx
@@ -4,14 +4,15 @@ import ServerError from '../pages/ServerError'
 import { NotificationContextType } from '../../types/contexts'
 import { UnauthorizedAdminAccess } from '../../types/errors'
 import AdminAccessPrevention from '../pages/AdminAccessPrevention'
+import ErrorBoundaryContext from '../../contexts/error-boundary-context'
 
 type ErrorBoundaryProps = {
-  children?: ReactNode;
+  children?: ReactNode
 }
 
 interface ErrorBoundaryState {
-  hasError: boolean;
-  error?: Error;
+  hasError: boolean
+  error?: Error
 }
 
 /**
@@ -29,9 +30,16 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   }
 
   // eslint-disable-next-line unused-imports/no-unused-vars
-  public componentDidCatch (error: Error, errorInfo: ErrorInfo) {
+  public componentDidCatch (error: Error, _errorInfo: ErrorInfo) {
     // todo log to sentry
     console.log(error)
+  }
+
+  public triggerError = (error: Error, _errorInfo?: ErrorInfo) => {
+    // todo log to sentry
+    console.log(error)
+
+    this.setState({ hasError: true })
   }
 
   /**
@@ -39,7 +47,14 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
    * the component tree.
    */
   public render () {
-    return this.state.hasError ? this.renderErrorPage() : this.props.children
+    return <>
+      <ErrorBoundaryContext.Provider value={{ triggerError: this.triggerError }}>
+        {this.state.hasError
+          ? this.renderErrorPage()
+          : this.props.children
+        }
+      </ErrorBoundaryContext.Provider>
+    </>
   }
 
   private renderErrorPage () {

--- a/src/contexts/error-boundary-context.ts
+++ b/src/contexts/error-boundary-context.ts
@@ -1,0 +1,8 @@
+import React from 'react'
+import { ErrorBoundaryContextType } from '../types/contexts'
+
+// eslint-disable-next-line n/handle-callback-err
+// const ErrorBoundaryContext = React.createContext((error: Error, errorInfo?: ErrorInfo): void => { /* template function */ })
+const ErrorBoundaryContext = React.createContext<ErrorBoundaryContextType>(null!)
+
+export default ErrorBoundaryContext

--- a/src/hooks/use-error-handling.ts
+++ b/src/hooks/use-error-handling.ts
@@ -1,0 +1,6 @@
+import ErrorBoundaryContext from '../contexts/error-boundary-context'
+import { useContext } from 'react'
+
+const useErrorHandling = () => useContext(ErrorBoundaryContext)
+
+export default useErrorHandling

--- a/src/services/api-service.ts
+++ b/src/services/api-service.ts
@@ -87,7 +87,7 @@ export default abstract class APIService {
     return wrapper
   }
 
-  protected createResponseWrapper (success: boolean, statusCode: number, statusMessage: string): ApiResponseWrapper {
+  private createResponseWrapper (success: boolean, statusCode: number, statusMessage: string): ApiResponseWrapper {
     return { success, statusCode, statusMessage }
   }
 

--- a/src/services/local-database-service.ts
+++ b/src/services/local-database-service.ts
@@ -34,14 +34,16 @@ export default class LocalDatabaseService {
   }
 
   public async addTourList (tours: Tour[]): Promise<void> {
-    // remove all synced tours
-    const syncedTours = await localDB.tours.where('status').equals(TourStatusType.SYNCED)
-      .and((tour: Tour) => tour.userId === this.userId!).toArray()
-    await localDB.tours.bulkDelete(syncedTours.map((tour: Tour) => tour.id))
+    await localDB.transaction('rw', localDB.tours, async () => {
+      // remove all synced tours
+      const syncedTours = await localDB.tours.where('status').equals(TourStatusType.SYNCED)
+        .and((tour: Tour) => tour.userId === this.userId!).toArray()
+      await localDB.tours.bulkDelete(syncedTours.map((tour: Tour) => tour.id))
 
-    for (const tour of tours) {
-      await localDB.tours.put(tour)
-    }
+      for (const tour of tours) {
+        await localDB.tours.put(tour)
+      }
+    })
   }
 
   public async findAllTours (): Promise<Tour[]> {

--- a/src/types/contexts.ts
+++ b/src/types/contexts.ts
@@ -3,6 +3,7 @@ import { AppTheme } from './theme'
 import { handleSave } from './handle-save'
 import { CurrentUpload, ImageUpload } from './media'
 import { ConnectionStatus } from '../enums/connection-status'
+import { ErrorInfo } from 'react'
 
 export interface TourListContextProperties {
   deleteEvent: (id: string) => void
@@ -49,4 +50,8 @@ export interface ImageUploadContextType {
   save: handleSave<File[]>
   remove: (id: string) => void
   currentUploads: CurrentUpload[]
+}
+
+export interface ErrorBoundaryContextType{
+  triggerError: (error: Error, errorInfo?: ErrorInfo) => void
 }


### PR DESCRIPTION
I had to extend the error boundary component as errors inside of async functions were not automatically caught. I added a context and a hook so now we can trigger the errors manually too (all errors that are happening outside of async functions will still be caught automatically).