### PR TITLE
Fix error where gpx upload errors were not properly cleaned

### DIFF
--- a/src/components/pages/tours/TourCreate.tsx
+++ b/src/components/pages/tours/TourCreate.tsx
@@ -32,7 +32,7 @@ const TourCreate = () => {
   const throwError = useApiError()
   const [images, setImages] = useState<ImageUpload[]>([])
   const { handleImageUpload, currentUploads } = useHandleImageUpload(mediaService, images, setImages)
-  const [gpxFile, setGpxFile] = useState<GpxFileUpload>(null!)
+  const [gpxFile, setGpxFile] = useState<GpxFileUpload|undefined>(undefined)
   const { handleGpxFileUpload, currentGpxUpload } = useHandleGpxFileUpload(mediaService, gpxFile, setGpxFile)
   const checkConnection = useCheckConnection()
   const { triggerError } = useErrorHandling()
@@ -107,7 +107,7 @@ const TourCreate = () => {
   }
 
   const removeGpxFile = useCallback(() => {
-    setGpxFile(null!)
+    setGpxFile(undefined)
   }, [gpxFile])
 
   const gpxFileContextProps: GpxFileUploadContextType = {

--- a/src/components/pages/tours/TourEdit.tsx
+++ b/src/components/pages/tours/TourEdit.tsx
@@ -37,7 +37,7 @@ const EditTour = () => {
   const throwError = useApiError()
   const [images, setImages] = useState<ImageUpload[]>([])
   const { handleImageUpload, currentUploads } = useHandleImageUpload(mediaService, images, setImages)
-  const [gpxFile, setGpxFile] = useState<GpxFileUpload>(null!)
+  const [gpxFile, setGpxFile] = useState<GpxFileUpload|undefined>(undefined)
   const { handleGpxFileUpload, currentGpxUpload } = useHandleGpxFileUpload(mediaService, gpxFile, setGpxFile)
   const { isOffline } = useConnectionStatus()
   const { triggerError } = useErrorHandling()
@@ -134,7 +134,7 @@ const EditTour = () => {
   }, [images])
 
   const removeGpxFile = useCallback(() => {
-    setGpxFile(null!)
+    setGpxFile(undefined)
   }, [gpxFile])
 
   const imageContextProps: ImageUploadContextType = {

--- a/src/components/shared/gpx-files/upload/GpxFileUploadProgress.tsx
+++ b/src/components/shared/gpx-files/upload/GpxFileUploadProgress.tsx
@@ -12,7 +12,7 @@ export type GpxUploadErrorListItem = {
 
 const GpxFileUploadProgress = () => {
   const { currentUpload } = useGpxFileUpload()
-  const [uploadError, setUploadError] = useState<GpxUploadErrorListItem>(null!)
+  const [uploadError, setUploadError] = useState<GpxUploadErrorListItem|null>(null)
 
   useEffect(() => {
     if (currentUpload && currentUpload.error?.reason) {
@@ -20,6 +20,8 @@ const GpxFileUploadProgress = () => {
         file: currentUpload.name,
         reason: currentUpload.error.reason
       })
+    } else {
+      setUploadError(null)
     }
   }, [currentUpload])
 

--- a/src/hooks/use-handle-gpx-file-upload.ts
+++ b/src/hooks/use-handle-gpx-file-upload.ts
@@ -4,7 +4,7 @@ import useApiError from './use-api-error'
 import { CurrentUpload, GpxFileUpload, UploadError } from '../types/media'
 import useErrorHandling from './use-error-handling'
 
-const useHandleGpxFileUpload = (mediaService: MediaService, record: GpxFileUpload, setRecord: Dispatch<SetStateAction<GpxFileUpload>>) => {
+const useHandleGpxFileUpload = (mediaService: MediaService, record: GpxFileUpload|undefined, setRecord: Dispatch<SetStateAction<GpxFileUpload|undefined>>) => {
   const throwError = useApiError()
   const { triggerError } = useErrorHandling()
   const [currentGpxUpload, setCurrentGpxUpload] = useState<CurrentUpload>(null!)
@@ -32,9 +32,10 @@ const useHandleGpxFileUpload = (mediaService: MediaService, record: GpxFileUploa
     async (uploadedGpxFile: File) => {
       setCurrentGpxUpload(prevState => ({
         ...prevState,
-        name: uploadedGpxFile.name
+        name: uploadedGpxFile.name,
+        error: undefined
       }))
-      setRecord(null!)
+      setRecord(undefined)
 
       try {
         const data = await mediaService.uploadGpxFile(uploadedGpxFile)


### PR DESCRIPTION
Fixes #144 

I also removed the `null!` assertions by typing it with `...|undefined` and setting it to `undefined` if there is no upload.