### PR TITLE
Fix/prevent auth pages for logged in users

### DIFF
--- a/src/components/auth/RequireAnonymous.tsx
+++ b/src/components/auth/RequireAnonymous.tsx
@@ -12,10 +12,10 @@ type RequireAnonymousProps = {
  * @constructor
  */
 const RequireAnonymous = ({ children }: RequireAnonymousProps): JSX.Element => {
-  const { email } = useAuth()
+  const { isLoggedIn } = useAuth()
   const location = useLocation()
 
-  if (email) {
+  if (isLoggedIn) {
     return <Navigate to="/" state={{ from: location }} replace/>
   }
 

--- a/src/components/auth/RequireAnonymous.tsx
+++ b/src/components/auth/RequireAnonymous.tsx
@@ -1,0 +1,25 @@
+import useAuth from '../../hooks/use-auth'
+import { Navigate, useLocation } from 'react-router'
+import React from 'react'
+
+type RequireAnonymousProps = {
+  children: JSX.Element;
+}
+
+/**
+ * Shortcut for creating pages that cannot be accessed by logged-in users (e.g. login route). Redirects to home.
+ * @param children
+ * @constructor
+ */
+const RequireAnonymous = ({ children }: RequireAnonymousProps): JSX.Element => {
+  const { email } = useAuth()
+  const location = useLocation()
+
+  if (email) {
+    return <Navigate to="/" state={{ from: location }} replace/>
+  }
+
+  return children
+}
+
+export default RequireAnonymous

--- a/src/components/auth/RequireAuth.tsx
+++ b/src/components/auth/RequireAuth.tsx
@@ -15,10 +15,10 @@ type RequireAuthProps = {
  * @constructor
  */
 const RequireAuth = ({ children, requireAdmin = false }: RequireAuthProps): JSX.Element => {
-  const { email, isAdmin } = useAuth()
+  const { isLoggedIn, isAdmin } = useAuth()
   const location = useLocation()
 
-  if (!email) {
+  if (!isLoggedIn) {
     return <Navigate to="/login" state={{ from: location }} replace/>
   }
 

--- a/src/components/auth/RequireAuth.tsx
+++ b/src/components/auth/RequireAuth.tsx
@@ -8,7 +8,13 @@ type RequireAuthProps = {
   requireAdmin?: boolean;
 }
 
-const RequireAuth = ({ children, requireAdmin = false }: RequireAuthProps) : JSX.Element => {
+/**
+ * Shortcut for creating pages that can only be accessed by logged-in users (e.g. tours). Redirects to login otherwise.
+ * @param children
+ * @param requireAdmin If true, also checks for admin rights and raises an UnauthorizedAdminAccess exception otherwise.
+ * @constructor
+ */
+const RequireAuth = ({ children, requireAdmin = false }: RequireAuthProps): JSX.Element => {
   const { email, isAdmin } = useAuth()
   const location = useLocation()
 

--- a/src/components/landing-page/Hero.tsx
+++ b/src/components/landing-page/Hero.tsx
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom'
 import useAuth from '../../hooks/use-auth'
 
 const Hero = () => {
-  const { email } = useAuth()
+  const { isLoggedIn } = useAuth()
 
   return (
     <Box
@@ -21,14 +21,14 @@ const Hero = () => {
           gutterBottom
         >
           {
-            email
+            isLoggedIn
               ? <>Welcome back!</>
               : <>You have arrived.</>
           }
         </Typography>
         <Typography variant="h5" align="center" color="text.secondary" paragraph>
           {
-            email
+            isLoggedIn
               ? <>We are glad to have you on board.</>
               : <>Fellow hiker, you have arrived. <strong>gipfeli.io</strong> is the last hike documentation website you
                 will ever need. So stop searching and join us!</>
@@ -41,7 +41,7 @@ const Hero = () => {
           justifyContent="center"
         >
           {
-            email
+            isLoggedIn
               ? <Button component={Link} to="tours" variant="contained">To your tours</Button>
               : <Button component={Link} to="signup" variant="contained">Sign up</Button>
           }

--- a/src/components/landing-page/Hero.tsx
+++ b/src/components/landing-page/Hero.tsx
@@ -2,8 +2,11 @@ import { Box, Button, Container, Stack } from '@mui/material'
 import Typography from '@mui/material/Typography'
 import React from 'react'
 import { Link } from 'react-router-dom'
+import useAuth from '../../hooks/use-auth'
 
 const Hero = () => {
+  const { email } = useAuth()
+
   return (
     <Box
       sx={{
@@ -17,11 +20,19 @@ const Hero = () => {
           align="center"
           gutterBottom
         >
-          You&apos;ve arrived.
+          {
+            email
+              ? <>Welcome back!</>
+              : <>You have arrived.</>
+          }
         </Typography>
         <Typography variant="h5" align="center" color="text.secondary" paragraph>
-          Fellow hiker, you have arrived. <strong>gipfeli.io</strong> is the last hike documentation website you will
-          ever need. So stop searching and join us!
+          {
+            email
+              ? <>We are glad to have you on board.</>
+              : <>Fellow hiker, you have arrived. <strong>gipfeli.io</strong> is the last hike documentation website you
+                will ever need. So stop searching and join us!</>
+          }
         </Typography>
         <Stack
           sx={{ pt: 4 }}
@@ -29,7 +40,11 @@ const Hero = () => {
           spacing={2}
           justifyContent="center"
         >
-          <Button component={Link} to="signup" variant="contained">Sign up</Button>
+          {
+            email
+              ? <Button component={Link} to="tours" variant="contained">To your tours</Button>
+              : <Button component={Link} to="signup" variant="contained">Sign up</Button>
+          }
         </Stack>
       </Container>
     </Box>

--- a/src/components/pages/layouts/AuthPageLayout.tsx
+++ b/src/components/pages/layouts/AuthPageLayout.tsx
@@ -7,56 +7,59 @@ import LandscapeIcon from '@mui/icons-material/Landscape'
 import Typography from '@mui/material/Typography'
 import Footer from '../../shared/Footer'
 import { Link, Outlet } from 'react-router-dom'
+import RequireAnonymous from '../../auth/RequireAnonymous'
 
 const AuthPageLayout = () => (
-  <>
-    <AppBar position="fixed" color="transparent" elevation={0}>
-      <Toolbar>
-        <Link to={'/'}>
-          <IconButton
-            size="large"
-            edge="start"
-            sx={{ mr: 2 }}
-          >
-            <LandscapeIcon/>
-          </IconButton>
-        </Link>
-        <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
-          gipfeli.io
-        </Typography>
-      </Toolbar>
-    </AppBar>
-    <Grid container component="main" sx={{ height: '100vh' }}>
-      <Grid
-        item
-        xs={false}
-        sm={4}
-        md={7}
-        sx={{
-          backgroundImage: 'url(https://source.unsplash.com/random/?mountains)',
-          backgroundRepeat: 'no-repeat',
-          backgroundSize: 'cover',
-          backgroundPosition: 'center'
-        }}
-      />
-      <Grid item xs={12} sm={8} md={5} component={Paper} elevation={6} square>
-        <Box
+  <RequireAnonymous>
+    <>
+      <AppBar position="fixed" color="transparent" elevation={0}>
+        <Toolbar>
+          <Link to={'/'}>
+            <IconButton
+              size="large"
+              edge="start"
+              sx={{ mr: 2 }}
+            >
+              <LandscapeIcon/>
+            </IconButton>
+          </Link>
+          <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+            gipfeli.io
+          </Typography>
+        </Toolbar>
+      </AppBar>
+      <Grid container component="main" sx={{ height: '100vh' }}>
+        <Grid
+          item
+          xs={false}
+          sm={4}
+          md={7}
           sx={{
-            my: 8,
-            mx: 4,
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center'
+            backgroundImage: 'url(https://source.unsplash.com/random/?mountains)',
+            backgroundRepeat: 'no-repeat',
+            backgroundSize: 'cover',
+            backgroundPosition: 'center'
           }}
-        >
+        />
+        <Grid item xs={12} sm={8} md={5} component={Paper} elevation={6} square>
+          <Box
+            sx={{
+              my: 8,
+              mx: 4,
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center'
+            }}
+          >
 
-          <Outlet/>
+            <Outlet/>
 
-        </Box>
-        <Footer/>
+          </Box>
+          <Footer/>
+        </Grid>
       </Grid>
-    </Grid>
-  </>
+    </>
+  </RequireAnonymous>
 )
 
 export default AuthPageLayout

--- a/src/components/providers/AuthenticationProvider.tsx
+++ b/src/components/providers/AuthenticationProvider.tsx
@@ -58,6 +58,10 @@ const AuthenticationProvider = ({ children }: PropsWithChildren<any>) => {
     return userRole === UserRole.ADMINISTRATOR
   }, [userRole])
 
+  const isLoggedIn = useMemo(() => {
+    return !!email
+  }, [email])
+
   const signIn = async (emailAddress: string, password: string, callback: () => void): Promise<void> => {
     const data = await authService.login(
       emailAddress,
@@ -169,7 +173,7 @@ const AuthenticationProvider = ({ children }: PropsWithChildren<any>) => {
    */
   useInterval(checkAndRefreshToken, 2000)
 
-  const value: AuthenticationContextType = { email, isAdmin, token: accessToken, signIn, signOut }
+  const value: AuthenticationContextType = { email, isAdmin, isLoggedIn, token: accessToken, signIn, signOut }
 
   if (loading) {
     return <Loader/>

--- a/src/components/shared/navbar/ResponsiveAppBar.tsx
+++ b/src/components/shared/navbar/ResponsiveAppBar.tsx
@@ -38,9 +38,9 @@ const adminPage: NavItem[] = [
 ]
 
 const ResponsiveAppBar = () => {
-  const { email, isAdmin } = useAuth()
+  const { isLoggedIn, isAdmin } = useAuth()
   const pages = useMemo<NavItem[]>(() => {
-    if (!email) {
+    if (!isLoggedIn) {
       return []
     }
     if (isAdmin) {
@@ -48,9 +48,9 @@ const ResponsiveAppBar = () => {
     } else {
       return appPages
     }
-  }, [email, isAdmin])
+  }, [isLoggedIn, isAdmin])
 
-  const homeRoute = email ? '/tours' : '/'
+  const homeRoute = isLoggedIn ? '/tours' : '/'
 
   return (
     <AppBar position="static">

--- a/src/types/contexts.ts
+++ b/src/types/contexts.ts
@@ -15,6 +15,7 @@ export interface ListContextProperties {
 
 export interface AuthenticationContextType {
   email: string | undefined
+  isLoggedIn: boolean
   isAdmin: boolean
   token: string | undefined
   signIn: (email: string, password: string, callback: () => void) => Promise<void>


### PR DESCRIPTION
Fixes #142 

I also added a convenience helper on `useAuth` so we do not have to check for the `email` property. It's more clear this way.