### PR TITLE
Fix missing DOM id for ol-ext

### DIFF
--- a/src/components/shared/map/MapWrapper.tsx
+++ b/src/components/shared/map/MapWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, useEffect, useId, useState } from 'react'
+import React, { PropsWithChildren, useId, useLayoutEffect, useState } from 'react'
 import { Map, View } from 'ol'
 import 'ol/ol.css'
 import TileLayer from 'ol/layer/Tile'
@@ -14,7 +14,17 @@ const MapWrapper = ({ children }: PropsWithChildren<any>) => {
   const mapContainerId = useId()
   const [map, setMap] = useState<Map | undefined>(undefined)
 
-  useEffect(() => {
+  /**
+   * Notice that we use useLayoutEffect() instead of useEffect(). The reason for this is that when we call dispose() on
+   * the map object while a user is hovering over an instance of ol-ext's Hover interaction (e.g. GPX track), so e.g.
+   * when the user hovers and then hits the return button; in that moment ol-ext needs to have the DOM present to get
+   * the default cursor (see https://github.com/Viglino/ol-ext/blob/master/src/interaction/Hover.js#L66). When we use
+   * useEffect(), ol-ext calls getTargetElement() on the map object, but at that point, the target element is already
+   * removed from the DOM.
+   *
+   * Note: It would actually be better if ol-ext would not be DOM-dependent, i.e. falling back to a default cursor.
+   */
+  useLayoutEffect(() => {
     const initialMap = new Map({
       target: mapContainerId,
       layers: [


### PR DESCRIPTION
Fixes #165 

The bug only happened when a user was actively hovering over the GPX track and then e.g. navigated back, forcing `map.dispose()` to run.

The only change is to use `useLayoutEffect()` which runs synchronously, because with `useEffect()`, at the time when ol-ext calls `map.getTargetElement()`, that one is already `null`, raising an error.